### PR TITLE
Maintenance: upgrade java, clean dependencies & improve CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: ☕ Set up JDK 17
+      - name: ☕ Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: 🔦 Lint
         run: ./mvnw -B --no-transfer-progress spotless:check
       - name: ✅ Test & Build
-        run: ./mvnw -B --no-transfer-progress install
+        run: ./mvnw -B -DskipLint=true --no-transfer-progress install

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,10 +61,10 @@ jobs:
           # queries: security-extended,security-and-quality
 
       ## Custom: add java-17 setup to work with CodeQL
-      - name: Set up JDK 17
+      - name: ☕ Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- skip variable-->
-        <skipLint>true</skipLint>
+        <skipLint>false</skipLint>
         <!-- VERSIONS -->
         <!-- annotation processors -->
         <lombok.version>1.18.30</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,11 @@
         <okhttp.bom.version>4.12.0</okhttp.bom.version>
         <retrofit.version>2.9.0</retrofit.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <slf4j.version>2.0.9</slf4j.version>
         <!-- infrastructure dependencies -->
         <spring-boot-dependencies.bom.version>3.2.0</spring-boot-dependencies.bom.version>
         <picocli.version>4.7.5</picocli.version>
         <nitrite.version>3.4.4</nitrite.version>
-        <logback-classic.version>1.4.14</logback-classic.version>
         <!-- test dependencies -->
-        <junit.bom.version>5.10.1</junit.bom.version>
-        <assertj.bom.version>3.24.2</assertj.bom.version>
         <approvaltests.version>22.3.3</approvaltests.version>
         <instancio-junit.version>3.6.0</instancio-junit.version>
         <jimfs.version>1.3.0</jimfs.version>
@@ -254,16 +250,6 @@
             </dependency>
             <!-- singular dependencies -->
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${logback-classic.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.squareup.retrofit2</groupId>
                 <artifactId>retrofit</artifactId>
                 <version>${retrofit.version}</version>
@@ -300,21 +286,6 @@
                 </exclusions>
             </dependency>
             <!--TEST DEPENDENCIES-->
-            <!-- bom dependencies -->
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-bom</artifactId>
-                <version>${assertj.bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <!-- singular dependencies -->
             <dependency>
                 <groupId>com.approvaltests</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- skip variable-->
+        <skipLint>true</skipLint>
         <!-- VERSIONS -->
         <!-- annotation processors -->
         <lombok.version>1.18.30</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,10 @@
     <name>YGOJSON Parent</name>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>21</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- VERSIONS -->
         <!-- annotation processors -->
@@ -26,18 +28,18 @@
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <slf4j.version>2.0.9</slf4j.version>
         <!-- infrastructure dependencies -->
-        <spring-boot-dependencies.bom.version>3.1.6</spring-boot-dependencies.bom.version>
+        <spring-boot-dependencies.bom.version>3.2.0</spring-boot-dependencies.bom.version>
         <picocli.version>4.7.5</picocli.version>
         <nitrite.version>3.4.4</nitrite.version>
-        <logback-classic.version>1.4.11</logback-classic.version>
+        <logback-classic.version>1.4.14</logback-classic.version>
         <!-- test dependencies -->
         <junit.bom.version>5.10.1</junit.bom.version>
         <assertj.bom.version>3.24.2</assertj.bom.version>
-        <approvaltests.version>22.3.1</approvaltests.version>
+        <approvaltests.version>22.3.3</approvaltests.version>
         <instancio-junit.version>3.6.0</instancio-junit.version>
         <jimfs.version>1.3.0</jimfs.version>
         <!-- reporting dependencies-->
-        <jacoco.version>0.8.8</jacoco.version>
+        <jacoco.version>0.8.11</jacoco.version>
     </properties>
 
     <modules>
@@ -99,6 +101,7 @@
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <configuration>
+                    <skip>${skipLint}</skip>
                     <java>
                         <!-- use prettier-java -->
                         <prettier>
@@ -127,12 +130,30 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <banDuplicatePomDependencyVersions/>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- jacoco should also run on all tests to provide a coverage report -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -176,6 +197,16 @@
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
                     <version>2.40.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- Upgrade to java-21
- Add skipLint option and use on the CI/CD to avoid duplicated check
- Update dependencies & rely on spring-boot-dependencies for some of them