### PR TITLE
Create client helper classes with API-ettiquete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <jakarta-jakartaee.bom.version>10.0.0</jakarta-jakartaee.bom.version>
         <jsonschema-generator.bom.version>4.33.0</jsonschema-generator.bom.version>
         <okhttp.bom.version>4.12.0</okhttp.bom.version>
+        <resilience4j.bom.version>2.1.0</resilience4j.bom.version>
         <retrofit.version>2.9.0</retrofit.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <!-- infrastructure dependencies -->
@@ -245,6 +246,13 @@
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-generator-bom</artifactId>
                 <version>${jsonschema-generator.bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-bom</artifactId>
+                <version>${resilience4j.bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -66,6 +66,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -75,6 +79,11 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tools/src/integration-test/java/io/github/ygojson/tools/client/yugipedia/YugipediaApiIT.java
+++ b/tools/src/integration-test/java/io/github/ygojson/tools/client/yugipedia/YugipediaApiIT.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api;
+package io.github.ygojson.tools.client.yugipedia;
 
 import java.io.IOException;
 
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import retrofit2.Response;
 
-import io.github.ygojson.tools.yugipedia.api.params.Category;
-import io.github.ygojson.tools.yugipedia.api.params.PipeSeparated;
-import io.github.ygojson.tools.yugipedia.api.params.SortDirection;
-import io.github.ygojson.tools.yugipedia.api.response.Continue;
-import io.github.ygojson.tools.yugipedia.api.response.QueryResponse;
+import io.github.ygojson.tools.client.yugipedia.params.Category;
+import io.github.ygojson.tools.client.yugipedia.params.PipeSeparated;
+import io.github.ygojson.tools.client.yugipedia.params.SortDirection;
+import io.github.ygojson.tools.client.yugipedia.response.Continue;
+import io.github.ygojson.tools.client.yugipedia.response.QueryResponse;
 
 @Slf4j
 class YugipediaApiIT {
@@ -21,7 +21,7 @@ class YugipediaApiIT {
 
 	@BeforeEach
 	void beforeEach() {
-		api = YugipediaApiMother.productionClient();
+		api = YugipediaApiMother.productionTestClient();
 	}
 
 	private Response<QueryResponse> doExecuteTestQueryCategoryMembersByTimestamp(final String gmcontinue) throws IOException {

--- a/tools/src/main/java/io/github/ygojson/tools/AppConfiguration.java
+++ b/tools/src/main/java/io/github/ygojson/tools/AppConfiguration.java
@@ -1,10 +1,12 @@
 package io.github.ygojson.tools;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import io.github.ygojson.model.utils.JsonUtils;
+import io.github.ygojson.tools.common.ApplicationInfo;
 
 /**
  * Application configuration.
@@ -23,5 +25,15 @@ public class AppConfiguration {
 	public ObjectMapper objectMapper() {
 		// use our model object-mapper
 		return JsonUtils.getObjectMapper();
+	}
+
+	// TODO: should add the variables on a different way
+	@Bean
+	public ApplicationInfo applicationInfo(
+		@Value("${application.title:ygojson-tools}") final String title,
+		@Value("${application.version:develop}") final String version,
+		@Value("${application.url:https://ygojson.github.io}") final String url
+	) {
+		return new ApplicationInfo(title, version, url);
 	}
 }

--- a/tools/src/main/java/io/github/ygojson/tools/AppConfiguration.java
+++ b/tools/src/main/java/io/github/ygojson/tools/AppConfiguration.java
@@ -27,7 +27,7 @@ public class AppConfiguration {
 		return JsonUtils.getObjectMapper();
 	}
 
-	// TODO: should add the variables on a different way
+	// TODO: fix properties management (see https://github.com/ygojson/ygojson-tools/issues/19)
 	@Bean
 	public ApplicationInfo applicationInfo(
 		@Value("${application.title:ygojson-tools}") final String title,

--- a/tools/src/main/java/io/github/ygojson/tools/client/ClientConfig.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/ClientConfig.java
@@ -1,0 +1,26 @@
+package io.github.ygojson.tools.client;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import io.github.ygojson.tools.common.ApplicationInfo;
+
+public interface ClientConfig<T> {
+	record RateLimit(int maxRequest, Duration duration) {}
+
+	String name();
+
+	Class<T> apiClass();
+
+	String baseUrl();
+
+	RateLimit rateLimit();
+
+	/**
+	 * Gets the supplier to build the user-agent given the current version of the tool.
+	 *
+	 * @param info information of the application.
+	 * @return supplier for the user-agent.
+	 */
+	Function<String, String> userAgentMapper(final ApplicationInfo info);
+}

--- a/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
@@ -45,7 +45,9 @@ public class ClientFactory {
 			.addNetworkInterceptor(
 				createRateLimitInterceptor(config.name(), config.rateLimit())
 			)
-			.addNetworkInterceptor(new UserAgentInterceptor(config.userAgentMapper(info)))
+			.addNetworkInterceptor(
+				new UserAgentInterceptor(config.userAgentMapper(info))
+			)
 			.build();
 	}
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
@@ -1,0 +1,68 @@
+package io.github.ygojson.tools.client;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+
+import io.github.ygojson.tools.common.ApplicationInfo;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ClientFactory {
+
+	private final ConcurrentHashMap<ClientConfig<?>, Retrofit> retrofitClients =
+		new ConcurrentHashMap<>();
+
+	private final ObjectMapper jsonMapper;
+	private final ApplicationInfo info;
+
+	public <T> T getClient(ClientConfig<T> config) {
+		final Retrofit retrofit = retrofitClients.computeIfAbsent(
+			config,
+			this::createRetrofit
+		);
+		return retrofit.create(config.apiClass());
+	}
+
+	private Retrofit createRetrofit(ClientConfig<?> config) {
+		return new Retrofit.Builder()
+			.baseUrl(config.baseUrl())
+			.client(createHttpClient(config))
+			.addConverterFactory(ScalarsConverterFactory.create())
+			.addConverterFactory(JacksonConverterFactory.create(jsonMapper))
+			.build();
+	}
+
+	private OkHttpClient createHttpClient(ClientConfig<?> config) {
+		return new OkHttpClient.Builder()
+			.addInterceptor(
+				createRateLimitInterceptor(config.name(), config.rateLimit())
+			)
+			.addInterceptor(new UserAgentInterceptor(config.userAgentMapper(info)))
+			.build();
+	}
+
+	private static RateLimitInterceptor createRateLimitInterceptor(
+		String name,
+		ClientConfig.RateLimit rateLimit
+	) {
+		final RateLimiterConfig rateLimitConfig = RateLimiterConfig
+			.custom()
+			.limitForPeriod(rateLimit.maxRequest())
+			.limitRefreshPeriod(rateLimit.duration())
+			.timeoutDuration(rateLimit.duration())
+			.build();
+		final RateLimiter rateLimiter = RateLimiterRegistry
+			.of(rateLimitConfig)
+			.rateLimiter(name);
+		return new RateLimitInterceptor(rateLimiter);
+	}
+}

--- a/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
@@ -15,7 +14,7 @@ import retrofit2.converter.scalars.ScalarsConverterFactory;
 
 import io.github.ygojson.tools.common.ApplicationInfo;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public class ClientFactory {
 
 	private final ConcurrentHashMap<ClientConfig<?>, Retrofit> retrofitClients =

--- a/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/ClientFactory.java
@@ -17,7 +17,7 @@ import io.github.ygojson.tools.common.ApplicationInfo;
 @RequiredArgsConstructor
 public class ClientFactory {
 
-	private final ConcurrentHashMap<ClientConfig<?>, Retrofit> retrofitClients =
+	private final ConcurrentHashMap<String, Retrofit> retrofitClients =
 		new ConcurrentHashMap<>();
 
 	private final ObjectMapper jsonMapper;
@@ -25,8 +25,8 @@ public class ClientFactory {
 
 	public <T> T getClient(ClientConfig<T> config) {
 		final Retrofit retrofit = retrofitClients.computeIfAbsent(
-			config,
-			this::createRetrofit
+			config.name(),
+			any -> createRetrofit(config)
 		);
 		return retrofit.create(config.apiClass());
 	}
@@ -42,10 +42,10 @@ public class ClientFactory {
 
 	private OkHttpClient createHttpClient(ClientConfig<?> config) {
 		return new OkHttpClient.Builder()
-			.addInterceptor(
+			.addNetworkInterceptor(
 				createRateLimitInterceptor(config.name(), config.rateLimit())
 			)
-			.addInterceptor(new UserAgentInterceptor(config.userAgentMapper(info)))
+			.addNetworkInterceptor(new UserAgentInterceptor(config.userAgentMapper(info)))
 			.build();
 	}
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/RateLimitInterceptor.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/RateLimitInterceptor.java
@@ -10,7 +10,6 @@ import okhttp3.MediaType;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-
 @RequiredArgsConstructor
 class RateLimitInterceptor implements Interceptor {
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/RateLimitInterceptor.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/RateLimitInterceptor.java
@@ -1,0 +1,56 @@
+package io.github.ygojson.tools.client;
+
+import java.io.IOException;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import lombok.RequiredArgsConstructor;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+// TODO: add tests
+@RequiredArgsConstructor
+class RateLimitInterceptor implements Interceptor {
+
+	private final RateLimiter rateLimiter;
+
+	@Override
+	public Response intercept(final Chain chain) throws IOException {
+		try {
+			return RateLimiter
+				.decorateCheckedSupplier(
+					rateLimiter,
+					() -> chain.proceed(chain.request())
+				)
+				.get();
+		} catch (final Throwable e) {
+			return handleFailure(e);
+		}
+	}
+
+	public Response handleFailure(Throwable throwable) throws IOException {
+		return switch (throwable) {
+			case RequestNotPermitted rnp -> tooManyRequestResponse();
+			case IllegalStateException ise -> tooManyRequestResponse();
+			case IOException ioe -> throw ioe;
+			default -> throw new RuntimeException(
+				"call::execute exception",
+				throwable
+			);
+		};
+	}
+
+	private Response tooManyRequestResponse() {
+		return new Response.Builder()
+			.code(429)
+			.body(
+				ResponseBody.create(
+					"Too many client requests",
+					MediaType.get("text/plain")
+				)
+			)
+			.build();
+	}
+}

--- a/tools/src/main/java/io/github/ygojson/tools/client/RateLimitInterceptor.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/RateLimitInterceptor.java
@@ -10,7 +10,7 @@ import okhttp3.MediaType;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-// TODO: add tests
+
 @RequiredArgsConstructor
 class RateLimitInterceptor implements Interceptor {
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/UserAgentInterceptor.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/UserAgentInterceptor.java
@@ -1,0 +1,33 @@
+package io.github.ygojson.tools.client;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@RequiredArgsConstructor
+class UserAgentInterceptor implements Interceptor {
+
+	private static final String USER_AGENT_HEADER_NAME = "User-Agent";
+
+	// using a function to support:
+	// 1. custom user-agents overrides
+	// 2. provide a rotating user-agent
+	// 3. include the default user-agent (if used on network interceptor)
+	private final Function<String, String> userAgentSupplier;
+
+	@Override
+	public Response intercept(final Chain chain) throws IOException {
+		final Request original = chain.request();
+		final String originalHeader = original.header(USER_AGENT_HEADER_NAME);
+		final Request request = original
+			.newBuilder()
+			.header(USER_AGENT_HEADER_NAME, userAgentSupplier.apply(originalHeader))
+			.method(original.method(), original.body())
+			.build();
+		return chain.proceed(request);
+	}
+}

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/YugipediaApi.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/YugipediaApi.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api;
+package io.github.ygojson.tools.client.yugipedia;
 
 import java.time.ZonedDateTime;
 
@@ -6,10 +6,10 @@ import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
-import io.github.ygojson.tools.yugipedia.api.params.Category;
-import io.github.ygojson.tools.yugipedia.api.params.PipeSeparated;
-import io.github.ygojson.tools.yugipedia.api.params.SortDirection;
-import io.github.ygojson.tools.yugipedia.api.response.QueryResponse;
+import io.github.ygojson.tools.client.yugipedia.params.Category;
+import io.github.ygojson.tools.client.yugipedia.params.PipeSeparated;
+import io.github.ygojson.tools.client.yugipedia.params.SortDirection;
+import io.github.ygojson.tools.client.yugipedia.response.QueryResponse;
 
 /**
  * Represents the Yugipedia API calls used by YGOJSON.
@@ -26,12 +26,12 @@ public interface YugipediaApi {
 	 */
 	@GET(
 		"api.php?action=query" +
-		"&format=json&formatversion=2" +
-		"&redirects=true" +
-		"&prop=revisions" +
-		"&rvprop=content|timestamp" +
-		"&generator=categorymembers" +
-		"&gcmsort=timestamp"
+			"&format=json&formatversion=2" +
+			"&redirects=true" +
+			"&prop=revisions" +
+			"&rvprop=content|timestamp" +
+			"&generator=categorymembers" +
+			"&gcmsort=timestamp"
 	)
 	public Call<QueryResponse> queryCategoryMembersByTimestamp(
 		@Query("gcmtitle") Category category,
@@ -50,14 +50,14 @@ public interface YugipediaApi {
 	 */
 	@GET(
 		"api.php?action=query" +
-		"&format=json&formatversion=2" +
-		"&redirects=true" +
-		"&prop=revisions|categories" +
-		"&rvprop=content|timestamp" +
-		"&generator=recentchanges" +
-		"&grctype=new|edit|categorize" +
-		"&grctoponly=true" +
-		"&cllimit=max"
+			"&format=json&formatversion=2" +
+			"&redirects=true" +
+			"&prop=revisions|categories" +
+			"&rvprop=content|timestamp" +
+			"&generator=recentchanges" +
+			"&grctype=new|edit|categorize" +
+			"&grctoponly=true" +
+			"&cllimit=max"
 	)
 	public Call<QueryResponse> queryRecentChanges(
 		@Query("grclimit") Integer resultsPerQuery,
@@ -73,10 +73,10 @@ public interface YugipediaApi {
 	 */
 	@GET(
 		"api.php?action=query" +
-		"&format=json&formatversion=2" +
-		"&redirects=true" +
-		"&prop=revisions" +
-		"&rvprop=content|timestamp"
+			"&format=json&formatversion=2" +
+			"&redirects=true" +
+			"&prop=revisions" +
+			"&rvprop=content|timestamp"
 	)
 	public Call<QueryResponse> queryPagesByTitle(
 		@Query("titles") PipeSeparated titles

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/YugipediaApi.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/YugipediaApi.java
@@ -26,12 +26,12 @@ public interface YugipediaApi {
 	 */
 	@GET(
 		"api.php?action=query" +
-			"&format=json&formatversion=2" +
-			"&redirects=true" +
-			"&prop=revisions" +
-			"&rvprop=content|timestamp" +
-			"&generator=categorymembers" +
-			"&gcmsort=timestamp"
+		"&format=json&formatversion=2" +
+		"&redirects=true" +
+		"&prop=revisions" +
+		"&rvprop=content|timestamp" +
+		"&generator=categorymembers" +
+		"&gcmsort=timestamp"
 	)
 	public Call<QueryResponse> queryCategoryMembersByTimestamp(
 		@Query("gcmtitle") Category category,
@@ -50,14 +50,14 @@ public interface YugipediaApi {
 	 */
 	@GET(
 		"api.php?action=query" +
-			"&format=json&formatversion=2" +
-			"&redirects=true" +
-			"&prop=revisions|categories" +
-			"&rvprop=content|timestamp" +
-			"&generator=recentchanges" +
-			"&grctype=new|edit|categorize" +
-			"&grctoponly=true" +
-			"&cllimit=max"
+		"&format=json&formatversion=2" +
+		"&redirects=true" +
+		"&prop=revisions|categories" +
+		"&rvprop=content|timestamp" +
+		"&generator=recentchanges" +
+		"&grctype=new|edit|categorize" +
+		"&grctoponly=true" +
+		"&cllimit=max"
 	)
 	public Call<QueryResponse> queryRecentChanges(
 		@Query("grclimit") Integer resultsPerQuery,
@@ -73,10 +73,10 @@ public interface YugipediaApi {
 	 */
 	@GET(
 		"api.php?action=query" +
-			"&format=json&formatversion=2" +
-			"&redirects=true" +
-			"&prop=revisions" +
-			"&rvprop=content|timestamp"
+		"&format=json&formatversion=2" +
+		"&redirects=true" +
+		"&prop=revisions" +
+		"&rvprop=content|timestamp"
 	)
 	public Call<QueryResponse> queryPagesByTitle(
 		@Query("titles") PipeSeparated titles

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/YugipediaConfig.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/YugipediaConfig.java
@@ -1,0 +1,67 @@
+package io.github.ygojson.tools.client.yugipedia;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import io.github.ygojson.tools.client.ClientConfig;
+import io.github.ygojson.tools.common.ApplicationInfo;
+
+public class YugipediaConfig implements ClientConfig<YugipediaApi> {
+
+	@Override
+	public String name() {
+		return "yugipedia";
+	}
+
+	@Override
+	public Class<YugipediaApi> apiClass() {
+		return YugipediaApi.class;
+	}
+
+	@Override
+	public String baseUrl() {
+		return "https://yugipedia.com";
+	}
+
+	@Override
+	public RateLimit rateLimit() {
+		return new RateLimit(
+			1,
+			Duration
+				.ofSeconds(1) // add some milliseconds to be sure that we don't hit it
+				.plus(250, ChronoUnit.MILLIS)
+		);
+	}
+
+	@Override
+	public Function<String, String> userAgentMapper(ApplicationInfo info) {
+		final String clientNameVersion = getClientNameVersion(info);
+		final String contactInfo = getContactInfo(info);
+		return original ->
+			String.join(
+				" ",
+				Stream
+					.of(clientNameVersion, contactInfo, original)
+					.filter(Objects::nonNull)
+					.toList()
+			);
+	}
+
+	private static String getContactInfo(ApplicationInfo info) {
+		return info.url() != null ? "(" + info.url() + ")" : null;
+	}
+
+	private static String getClientNameVersion(ApplicationInfo info) {
+		if (info.title() != null) {
+			return (
+				info.title() +
+				"/" +
+				(info.version() != null ? info.version() : "unknown")
+			);
+		}
+		return null;
+	}
+}

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/Category.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/Category.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.params;
+package io.github.ygojson.tools.client.yugipedia.params;
 
 import lombok.RequiredArgsConstructor;
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/PipeSeparated.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/PipeSeparated.java
@@ -14,7 +14,7 @@ public final class PipeSeparated {
 	private final List<String> values;
 
 	public PipeSeparated(final String... values) {
-		if (values==null || values.length >= 500) {
+		if (values == null || values.length >= 500) {
 			throw new IllegalArgumentException("Titles should be > 1 and <= 500");
 		}
 		this.values = List.of(values);

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/PipeSeparated.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/PipeSeparated.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.params;
+package io.github.ygojson.tools.client.yugipedia.params;
 
 import java.util.List;
 
@@ -14,7 +14,7 @@ public final class PipeSeparated {
 	private final List<String> values;
 
 	public PipeSeparated(final String... values) {
-		if (values == null || values.length >= 500) {
+		if (values==null || values.length >= 500) {
 			throw new IllegalArgumentException("Titles should be > 1 and <= 500");
 		}
 		this.values = List.of(values);

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/SortDirection.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/params/SortDirection.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.params;
+package io.github.ygojson.tools.client.yugipedia.params;
 
 import lombok.RequiredArgsConstructor;
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Categories.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Categories.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.response;
+package io.github.ygojson.tools.client.yugipedia.response;
 
 import lombok.Data;
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Continue.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Continue.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.response;
+package io.github.ygojson.tools.client.yugipedia.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Page.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Page.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.response;
+package io.github.ygojson.tools.client.yugipedia.response;
 
 import java.util.List;
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/QueryResponse.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/QueryResponse.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.response;
+package io.github.ygojson.tools.client.yugipedia.response;
 
 import java.util.List;
 

--- a/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Revision.java
+++ b/tools/src/main/java/io/github/ygojson/tools/client/yugipedia/response/Revision.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api.response;
+package io.github.ygojson.tools.client.yugipedia.response;
 
 import java.time.ZonedDateTime;
 

--- a/tools/src/main/java/io/github/ygojson/tools/common/ApplicationInfo.java
+++ b/tools/src/main/java/io/github/ygojson/tools/common/ApplicationInfo.java
@@ -1,0 +1,3 @@
+package io.github.ygojson.tools.common;
+
+public record ApplicationInfo(String title, String version, String url) {}

--- a/tools/src/test/java/io/github/ygojson/tools/AppConfigurationTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/AppConfigurationTest.java
@@ -1,0 +1,28 @@
+package io.github.ygojson.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.github.ygojson.tools.common.ApplicationInfo;
+
+@SpringBootTest
+class AppConfigurationTest {
+
+	@Autowired
+	private ApplicationInfo appInfo;
+
+	@Test
+	void testApplicationInfo() {
+		assertThat(appInfo)
+			.isEqualTo(
+				new ApplicationInfo(
+					"ygojson-tools",
+					"develop",
+					"https://ygojson.github.io"
+				)
+			);
+	}
+}

--- a/tools/src/test/java/io/github/ygojson/tools/client/ClientFactoryTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/ClientFactoryTest.java
@@ -1,0 +1,44 @@
+package io.github.ygojson.tools.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.ygojson.tools.client.yugipedia.YugipediaConfig;
+import io.github.ygojson.tools.common.ApplicationInfo;
+
+class ClientFactoryTest {
+
+	private static ClientFactory CLIENT_FACTORY;
+
+	@BeforeAll
+	static void beforeAll() {
+		CLIENT_FACTORY =
+			new ClientFactory(
+				new ObjectMapper(),
+				new ApplicationInfo("test", "test", "test")
+			);
+	}
+
+	public static Stream<Arguments> availableClients() {
+		return Stream.of(Arguments.of(new YugipediaConfig()));
+	}
+
+	@MethodSource("availableClients")
+	@ParameterizedTest
+	void given_availableClients_when_createClient_then_apiClassIsProvided(
+		final ClientConfig<?> config
+	) {
+		// given - factory
+		// when
+		final Object client = CLIENT_FACTORY.getClient(config);
+		// then
+		assertThat(client).isInstanceOf(config.apiClass());
+	}
+}

--- a/tools/src/test/java/io/github/ygojson/tools/client/RateLimitInterceptorTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/RateLimitInterceptorTest.java
@@ -95,7 +95,7 @@ class RateLimitInterceptorTest {
 		throws IOException {
 		// given
 		final OkHttpClient client = new OkHttpClient.Builder()
-			.addInterceptor(createTestInterceptor(1, Duration.ofMillis(100)))
+			.addNetworkInterceptor(createTestInterceptor(1, Duration.ofMillis(100)))
 			.build();
 		warmUp(client, 3);
 

--- a/tools/src/test/java/io/github/ygojson/tools/client/RateLimitInterceptorTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/RateLimitInterceptorTest.java
@@ -1,0 +1,124 @@
+package io.github.ygojson.tools.client;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class RateLimitInterceptorTest {
+
+	private static MockWebServer MOCK_SERVER;
+
+	@BeforeAll
+	static void beforeAll() {
+		MOCK_SERVER = new MockWebServer();
+		MOCK_SERVER.setDispatcher(
+			new Dispatcher() {
+				final AtomicLong nextCallId = new AtomicLong(0);
+
+				@Override
+				public MockResponse dispatch(RecordedRequest recordedRequest) {
+					long callId = nextCallId.getAndIncrement();
+					return new MockResponse()
+						.setBody(String.format("{testData: \"DUMMY-%s\"}", callId));
+				}
+			}
+		);
+	}
+
+	private RateLimitInterceptor createTestInterceptor(
+		final int maxRequest,
+		final Duration duration
+	) {
+		return new RateLimitInterceptor(
+			RateLimiter.of(
+				"test",
+				RateLimiterConfig
+					.custom()
+					.limitForPeriod(maxRequest)
+					.limitRefreshPeriod(duration)
+					.timeoutDuration(duration)
+					.build()
+			)
+		);
+	}
+
+	@AfterAll
+	static void afterAll() {
+		try {
+			MOCK_SERVER.close();
+			MOCK_SERVER = null;
+		} catch (final IOException e) {
+			log.error("Error closing mock-server", e);
+		}
+	}
+
+	private void warmUp(final OkHttpClient client, final int calls) {
+		IntStream
+			.range(0, calls)
+			.forEach(any -> {
+				try {
+					doRequest(client).body();
+				} catch (IOException e) {
+					log.error("warm-up request error");
+				}
+			});
+	}
+
+	private Response doRequest(final OkHttpClient client) throws IOException {
+		final Request request = new Request.Builder()
+			.url(MOCK_SERVER.url("/test"))
+			.build();
+		// execute the call
+		return client.newCall(request).execute();
+	}
+
+	@Test
+	public void given_oneMaxRequestPer100ms_when_secondRequest_then_callWaits()
+		throws IOException {
+		// given
+		final OkHttpClient client = new OkHttpClient.Builder()
+			.addInterceptor(createTestInterceptor(1, Duration.ofMillis(100)))
+			.build();
+		warmUp(client, 3);
+
+		// when
+		final Response firstResponse = doRequest(client);
+		final Instant afterFirst = Instant.now();
+		final Response secondResponse = doRequest(client);
+		final Instant afterSecond = Instant.now();
+
+		// then
+		SoftAssertions.assertSoftly(softly -> {
+			softly
+				.assertThat(firstResponse.code())
+				.describedAs(" first response code")
+				.isEqualTo(200);
+			softly
+				.assertThat(secondResponse.code())
+				.describedAs(" second response code")
+				.isEqualTo(200);
+			softly
+				.assertThat(Duration.between(afterFirst, afterSecond))
+				.describedAs("time between responses")
+				.isGreaterThanOrEqualTo(Duration.ofMillis(100));
+		});
+	}
+}

--- a/tools/src/test/java/io/github/ygojson/tools/client/RateLimitInterceptorTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/RateLimitInterceptorTest.java
@@ -115,10 +115,11 @@ class RateLimitInterceptorTest {
 				.assertThat(secondResponse.code())
 				.describedAs(" second response code")
 				.isEqualTo(200);
+			// testing with -10 milliseconds as the timing wiht mock-server are too fast
 			softly
 				.assertThat(Duration.between(afterFirst, afterSecond))
 				.describedAs("time between responses")
-				.isGreaterThanOrEqualTo(Duration.ofMillis(100));
+				.isGreaterThanOrEqualTo(Duration.ofMillis(90));
 		});
 	}
 }

--- a/tools/src/test/java/io/github/ygojson/tools/client/UserAgentInterceptorTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/UserAgentInterceptorTest.java
@@ -1,0 +1,110 @@
+package io.github.ygojson.tools.client;
+
+import java.io.IOException;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class UserAgentInterceptorTest {
+
+	private static MockWebServer MOCK_SERVER;
+
+	@BeforeAll
+	static void beforeAll() {
+		MOCK_SERVER = new MockWebServer();
+		MOCK_SERVER.setDispatcher(
+			new Dispatcher() {
+				@Override
+				public MockResponse dispatch(RecordedRequest recordedRequest)
+					throws InterruptedException {
+					final String header = recordedRequest.getHeader("User-Agent");
+					if (header == null) {
+						return new MockResponse().setResponseCode(400);
+					} else {
+						return new MockResponse().setResponseCode(200).setBody(header);
+					}
+				}
+			}
+		);
+	}
+
+	@AfterAll
+	static void afterAll() {
+		try {
+			MOCK_SERVER.close();
+			MOCK_SERVER = null;
+		} catch (final IOException e) {
+			log.error("Error closing mock-server", e);
+		}
+	}
+
+	private void assertUserAgentResponse(
+		final Response response,
+		final String expectedStartOfAgent
+	) throws IOException {
+		final String body = response.body().string();
+		SoftAssertions.assertSoftly(softly -> {
+			softly
+				.assertThat(response.code())
+				.describedAs("response code")
+				.isEqualTo(200);
+			softly
+				.assertThat(body)
+				.describedAs("body (agent string)")
+				.startsWith(expectedStartOfAgent);
+		});
+	}
+
+	@Test
+	void given_userAgentAppendingToOriginal_when_executeWithNetworkInterceptor_then_userAgentHeaderContainsOkhttp()
+		throws IOException {
+		// given
+		final UserAgentInterceptor testInterceptor =
+			new UserAgentInterceptor(original ->
+				"MyTool/v0.0.0 (http://example.org/MyTool) " + original
+			);
+		// when
+		final Response response = new OkHttpClient.Builder()
+			.addNetworkInterceptor(testInterceptor)
+			.build()
+			.newCall(new Request.Builder().url(MOCK_SERVER.url("/")).build())
+			.execute();
+		// then
+		assertUserAgentResponse(
+			response,
+			"MyTool/v0.0.0 (http://example.org/MyTool) okhttp/"
+		);
+	}
+
+	@Test
+	void given_userAgentAppendingToOriginal_when_executeWithInterceptor_then_userAgentHeaderDoesNotContainOkHttp()
+		throws IOException {
+		// given
+		final UserAgentInterceptor testInterceptor =
+			new UserAgentInterceptor(original ->
+				"MyTool/v0.0.0 (http://example.org/MyTool) " + original
+			);
+		// when
+		final Response response = new OkHttpClient.Builder()
+			.addInterceptor(testInterceptor)
+			.build()
+			.newCall(new Request.Builder().url(MOCK_SERVER.url("/")).build())
+			.execute();
+		// then
+		assertUserAgentResponse(
+			response,
+			"MyTool/v0.0.0 (http://example.org/MyTool) null"
+		);
+	}
+}

--- a/tools/src/test/java/io/github/ygojson/tools/client/yugipedia/YugipediaApiMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/yugipedia/YugipediaApiMother.java
@@ -1,4 +1,4 @@
-package io.github.ygojson.tools.yugipedia.api;
+package io.github.ygojson.tools.client.yugipedia;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -14,7 +14,7 @@ import io.github.ygojson.model.utils.JsonUtils;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class YugipediaApiMother {
 
-	public static YugipediaApi productionClient() {
+	public static YugipediaApi productionTestClient() {
 		return createClient("https://yugipedia.com", productionOkHttp());
 	}
 

--- a/tools/src/test/java/io/github/ygojson/tools/client/yugipedia/YugipediaConfigTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/client/yugipedia/YugipediaConfigTest.java
@@ -1,0 +1,74 @@
+package io.github.ygojson.tools.client.yugipedia;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.ygojson.tools.client.ClientConfig;
+import io.github.ygojson.tools.common.ApplicationInfo;
+
+class YugipediaConfigTest {
+
+	@Test
+	void given_configuration_when_rateLimit_then_isLargerThan1PerSecond() {
+		// given
+		final YugipediaConfig config = new YugipediaConfig();
+		// when
+		final ClientConfig.RateLimit limit = config.rateLimit();
+		// then
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(limit.maxRequest()).isEqualTo(1);
+			softly.assertThat(limit.duration()).isGreaterThan(Duration.ofSeconds(1));
+		});
+	}
+
+	public static Stream<Arguments> userAgentArguments() {
+		return Stream.of(
+			Arguments.of(
+				new ApplicationInfo("ygojson", "v0.0.0", "https://ygojson.github.io"),
+				"okhttp/${version}",
+				"ygojson/v0.0.0 (https://ygojson.github.io) okhttp/${version}"
+			),
+			Arguments.of(
+				new ApplicationInfo("ygojson", "v0.0.0", "https://ygojson.github.io"),
+				null,
+				"ygojson/v0.0.0 (https://ygojson.github.io)"
+			),
+			Arguments.of(new ApplicationInfo(null, null, null), null, ""),
+			Arguments.of(
+				new ApplicationInfo(null, "v0.0.0", "https://ygojson.github.io"),
+				"okhttp/${version}",
+				"(https://ygojson.github.io) okhttp/${version}"
+			),
+			Arguments.of(
+				new ApplicationInfo("ygojson", null, null),
+				"okhttp/${version}",
+				"ygojson/unknown okhttp/${version}"
+			)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("userAgentArguments")
+	void given_applicationInfo_when_userAgentMapperWithOriginalAgent_then_returnExpectedUserAgent(
+		final ApplicationInfo info,
+		final String originalAgent,
+		final String expectedAgent
+	) {
+		// given
+		final Function<String, String> userAgentMapper = new YugipediaConfig()
+			.userAgentMapper(info);
+		// when
+		final String userAgent = userAgentMapper.apply(originalAgent);
+		// then
+		assertThat(userAgent).isEqualTo(expectedAgent);
+	}
+}


### PR DESCRIPTION
- Move yugipedia.api under client module
- Add RateLimitInterceptor and UserAgentInterceptor to use on client creation
- Add ApplicationInfo (and loading with spring) for passing information to the user-agent
- Add ClientFactory for retrofit with API-ettiquete creation
- Add YugipediaConfig for client configuration