### PR TITLE
Separate chinese languages

### DIFF
--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Card.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Card.approved.json
@@ -238,7 +238,27 @@
             }
           }
         },
-        "zh" : {
+        "zh-Hans" : {
+          "type" : "object",
+          "properties" : {
+            "name" : {
+              "type" : "string"
+            },
+            "effectText" : {
+              "type" : "string"
+            },
+            "flavorText" : {
+              "type" : "string"
+            },
+            "materials" : {
+              "type" : "string"
+            },
+            "pendulumEffect" : {
+              "type" : "string"
+            }
+          }
+        },
+        "zh-Hant" : {
           "type" : "object",
           "properties" : {
             "name" : {

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Print.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Print.approved.json
@@ -28,7 +28,7 @@
     },
     "language" : {
       "type" : "string",
-      "enum" : [ "en", "de", "es", "fr", "it", "ja", "ko", "pt", "zh" ]
+      "enum" : [ "en", "de", "es", "fr", "it", "ja", "ko", "pt", "zh-Hans", "zh-Hant" ]
     }
   },
   "required" : [ "id", "cardId", "setId" ],

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Set.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Set.approved.json
@@ -108,7 +108,19 @@
             }
           }
         },
-        "zh" : {
+        "zh-Hans" : {
+          "type" : "object",
+          "properties" : {
+            "prefix" : {
+              "type" : "string",
+              "pattern" : "[a-zA-Z0-9]+-[a-zA-Z0-9]+"
+            },
+            "name" : {
+              "type" : "string"
+            }
+          }
+        },
+        "zh-Hant" : {
           "type" : "object",
           "properties" : {
             "prefix" : {

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Card.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Card.approved.json
@@ -25,7 +25,10 @@
         "pt" : {
           "$ref" : "#/$defs/CardText"
         },
-        "zh" : {
+        "zh-Hans" : {
+          "$ref" : "#/$defs/CardText"
+        },
+        "zh-Hant" : {
           "$ref" : "#/$defs/CardText"
         }
       }

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Print.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Print.approved.json
@@ -3,7 +3,7 @@
   "$defs" : {
     "Language" : {
       "type" : "string",
-      "enum" : [ "en", "de", "es", "fr", "it", "ja", "ko", "pt", "zh" ]
+      "enum" : [ "en", "de", "es", "fr", "it", "ja", "ko", "pt", "zh-Hans", "zh-Hant" ]
     }
   },
   "type" : "object",

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Set.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Set.approved.json
@@ -25,7 +25,10 @@
         "pt" : {
           "$ref" : "#/$defs/SetText"
         },
-        "zh" : {
+        "zh-Hans" : {
+          "$ref" : "#/$defs/SetText"
+        },
+        "zh-Hant" : {
           "$ref" : "#/$defs/SetText"
         }
       }

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Card.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Card.approved.json
@@ -25,21 +25,21 @@
   "linkArrows" : [ "middle-left", "top-center" ],
   "xyzRank" : 828415870,
   "localizedData" : {
-    "de" : {
-      "name" : "XYPEDCTCM",
-      "effectText" : "ZUMETFSA",
-      "flavorText" : "EGJUEPKGO",
-      "materials" : "XAU",
-      "pendulumEffect" : "DBYFL"
+    "pt" : {
+      "name" : "GBCUSP",
+      "effectText" : "IIAVKADE",
+      "flavorText" : "ABDIW",
+      "materials" : "HQJBH",
+      "pendulumEffect" : "YZDCC"
     },
-    "es" : {
+    "zh-Hans" : {
       "name" : "CILHPTA",
       "effectText" : "OBMP",
       "flavorText" : "DEGYRTKTC",
       "materials" : "LQWLX",
       "pendulumEffect" : "JPI"
     },
-    "it" : {
+    "zh-Hant" : {
       "name" : "XIVE",
       "effectText" : "RCITACUEF",
       "flavorText" : "JKTXAF",

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Print.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Print.approved.json
@@ -5,5 +5,5 @@
   "setPrefix" : "PMPYLWRK",
   "printNumber" : "MEOZGBOQAY",
   "rarity" : "UFOJ",
-  "language" : "it"
+  "language" : "zh-Hans"
 }

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Set.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Set.approved.json
@@ -5,17 +5,17 @@
   "type" : "JTGD",
   "series" : "XKRPVMWMMP",
   "localizedData" : {
-    "de" : {
-      "prefix" : "HTNSKCWA",
-      "name" : "IWSNLZXIFF"
+    "es" : {
+      "prefix" : "PTEQRGFNZ",
+      "name" : "JSJGG"
     },
     "fr" : {
-      "prefix" : "YHUF",
-      "name" : "JCMX"
-    },
-    "ko" : {
       "prefix" : "LWRKVM",
       "name" : "OZGBO"
+    },
+    "ko" : {
+      "prefix" : "YHUF",
+      "name" : "JCMX"
     }
   }
 }

--- a/model/src/main/java/io/github/ygojson/model/data/definition/localization/AbstractLocalizedData.java
+++ b/model/src/main/java/io/github/ygojson/model/data/definition/localization/AbstractLocalizedData.java
@@ -121,10 +121,21 @@ abstract class AbstractLocalizedData<T> {
 	 *
 	 * @return the translation
 	 */
-	@JsonProperty(value = LanguageProperties.ZH)
+	@JsonProperty(value = LanguageProperties.ZH_HANS)
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public T getZh() {
-		return getData(Language.ZH);
+	public T getZhHans() {
+		return getData(Language.ZH_HANS);
+	}
+
+	/**
+	 * Translation for chinese
+	 *
+	 * @return the translation
+	 */
+	@JsonProperty(value = LanguageProperties.ZH_HANT)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public T getZhHant() {
+		return getData(Language.ZH_HANT);
 	}
 
 	/**
@@ -190,12 +201,21 @@ abstract class AbstractLocalizedData<T> {
 	}
 
 	/**
-	 * Sets the Chinese translation
+	 * Sets the Simplified Chinese translation
 	 *
 	 * @param data the data for the language
 	 */
-	public void setZh(final T data) {
-		setData(Language.ZH, data);
+	public void setZhHans(final T data) {
+		setData(Language.ZH_HANS, data);
+	}
+
+	/**
+	 * Sets the Traditional Chinese translation
+	 *
+	 * @param data the data for the language
+	 */
+	public void setZhHant(final T data) {
+		setData(Language.ZH_HANT, data);
 	}
 
 	@Override

--- a/model/src/main/java/io/github/ygojson/model/data/definition/localization/Language.java
+++ b/model/src/main/java/io/github/ygojson/model/data/definition/localization/Language.java
@@ -62,5 +62,4 @@ public enum Language {
 	 */
 	@JsonProperty(value = LanguageProperties.ZH_HANT)
 	ZH_HANT,
-
 }

--- a/model/src/main/java/io/github/ygojson/model/data/definition/localization/Language.java
+++ b/model/src/main/java/io/github/ygojson/model/data/definition/localization/Language.java
@@ -7,25 +7,60 @@ import io.github.ygojson.model.data.property.LanguageProperties;
 /**
  * Enum values for the supported languages on YGOJSON.
  * <br>
- * These values follow the ISO 639-1 standard format.
+ * These values follow the IETF BCP 47 standard format.
  */
 public enum Language {
+	/**
+	 * English.
+	 * <br>
+	 * Note that this is the main language of YGOJSON.
+	 */
 	@JsonProperty(value = LanguageProperties.EN)
 	EN,
+	/**
+	 * German.
+	 */
 	@JsonProperty(value = LanguageProperties.DE)
 	DE,
+	/**
+	 * Spanish.
+	 */
 	@JsonProperty(value = LanguageProperties.ES)
 	ES,
+	/**
+	 * French.
+	 */
 	@JsonProperty(value = LanguageProperties.FR)
 	FR,
+	/**
+	 * Italian.
+	 */
 	@JsonProperty(value = LanguageProperties.IT)
 	IT,
+	/**
+	 * Japanese.
+	 */
 	@JsonProperty(value = LanguageProperties.JA)
 	JA,
+	/**
+	 * Korean.
+	 */
 	@JsonProperty(value = LanguageProperties.KO)
 	KO,
+	/**
+	 * Portuguese.
+	 */
 	@JsonProperty(value = LanguageProperties.PT)
 	PT,
-	@JsonProperty(value = LanguageProperties.ZH)
-	ZH,
+	/**
+	 * Chinese (Simplified).
+	 */
+	@JsonProperty(value = LanguageProperties.ZH_HANS)
+	ZH_HANS,
+	/**
+	 * Chinese (Traditional).
+	 */
+	@JsonProperty(value = LanguageProperties.ZH_HANT)
+	ZH_HANT,
+
 }

--- a/model/src/main/java/io/github/ygojson/model/data/property/LanguageProperties.java
+++ b/model/src/main/java/io/github/ygojson/model/data/property/LanguageProperties.java
@@ -61,12 +61,14 @@ public class LanguageProperties {
 	public static final String PT = "pt";
 
 	/**
-	 * Chinese localization property.
-	 * <br>
-	 * Localization in chinese can be using simplified
-	 * or traditional chinese.
+	 * Simplified chinese localization property.
 	 */
-	public static final String ZH = "zh";
+	public static final String ZH_HANS = "zh-Hans";
+
+	/**
+	 * Traditional chinese localization property.
+	 */
+	public static final String ZH_HANT = "zh-Hant";
 
 	private LanguageProperties() {
 		// contant class


### PR DESCRIPTION
As we are describing the text, we need to separate the language between traditional and simplified. We will do so changing the language to the `IETF BCP 4` standard.