### PR TITLE
Add PrintMother to simplify test-model refactors

### DIFF
--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapperUnitTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapperUnitTest.java
@@ -15,8 +15,10 @@ import org.mapstruct.factory.Mappers;
 
 import io.github.ygojson.model.data.Print;
 import io.github.ygojson.model.data.definition.localization.Language;
+import io.github.ygojson.model.data.definition.localization.Region;
 import io.github.ygojson.tools.dataprovider.impl.yugipedia.model.wikitext.CardTable2;
 import io.github.ygojson.tools.dataprovider.test.CardTable2Mother;
+import io.github.ygojson.tools.test.PrintMother;
 
 class YugipediaPrintMapperUnitTest {
 
@@ -24,79 +26,93 @@ class YugipediaPrintMapperUnitTest {
 		YugipediaPrintMapper.class
 	);
 
-	private static Print expectedFirstSeriesPrint(
-		final String setName,
-		final String rarity,
-		final Language language
-	) {
-		final Print print = new Print();
-		print.setFirstSeriesSet(setName);
-		print.setRarity(rarity);
-		print.setLanguage(language);
-		return print;
-	}
-
-	private static Print expectedPrint(
-		final String cardNumber,
-		final String rarity,
-		final Language language
-	) {
-		final Print print = new Print();
-		print.setPrintCode(cardNumber);
-		print.setRarity(rarity);
-		print.setLanguage(language);
-		return print;
-	}
-
 	// includes edge-cases for future development when the printCode is split (see #55)
 	static Stream<Arguments> printsToTest() {
 		return Stream.of(
 			// Series 1
 			Arguments.of(
-				CardTable2Mother.withOnlyJaSets("; Vol.1; Ultra Rare"),
-				expectedFirstSeriesPrint("Vol.1", "ultra rare", Language.JA)
+				PrintMother.firstSeriesOf("Vol.1", "ultra rare", Language.JA),
+				CardTable2Mother.withOnlyJaSets("; Vol.1; Ultra Rare")
 			),
 			// Series 2
 			Arguments.of(
-				CardTable2Mother.withOnlyJaSets("MRL-01; Magic Ruler; Common"),
-				expectedPrint("MRL-01", "common", Language.JA)
+				PrintMother.of("MRL-01", "MRL", 1, "common", Language.JA, Region.NONE),
+				CardTable2Mother.withOnlyJaSets("MRL-01; Magic Ruler; Common")
 			),
 			// Series 3
 			Arguments.of(
-				CardTable2Mother.withOnlyJaSets("301-001; The New Ruler; Common"),
-				expectedPrint("301-001", "common", Language.JA)
+				PrintMother.of("301-001", "301", 1, "common", Language.JA, Region.NONE),
+				CardTable2Mother.withOnlyJaSets("301-001; The New Ruler; Common")
 			),
 			// single letter (for some localization)
 			Arguments.of(
+				 PrintMother.of(
+					"BIP-S001",
+					"BIP",
+					1,
+					"ultra rare",
+					Language.ES,
+					Region.S
+				),
 				CardTable2Mother.withOnlySpSets(
 					"BIP-S001; Starter Deck: Pegasus; Ultra Rare"
-				),
-				expectedPrint("BIP-S001", "ultra rare", Language.ES)
+				)
 			),
 			// participation card
 			Arguments.of(
+				PrintMother.specialOf(
+					"ANPR-ENSP1",
+					"ANPR",
+					"SP",
+					1,
+					"ultra rare",
+					Language.EN,
+					Region.EN
+				),
 				CardTable2Mother.withOnlyEnSets(
 					"ANPR-ENSP1; Ancient Prophecy Sneak Peek Participation Card; Ultra Rare"
-				),
-				expectedPrint("ANPR-ENSP1", "ultra rare", Language.EN)
+				)
 			),
 			// legendary deck (have some special cases)
 			Arguments.of(
+				PrintMother.specialOf(
+					"YGLD-ENA00",
+					"YGLD",
+					"A",
+					0,
+					"secret rare",
+					Language.EN,
+					Region.EN
+				),
 				CardTable2Mother.withOnlyEnSets(
 					"YGLD-ENA00; Yugi's Legendary Decks; Secret Rare"
-				),
-				expectedPrint("YGLD-ENA00", "secret rare", Language.EN)
+				)
 			),
 			Arguments.of(
+				PrintMother.specialOf(
+					"LDK2-ENS01",
+					"LDK2",
+					"S",
+					1,
+					"ultra rare",
+					Language.EN,
+					Region.EN
+				),
 				CardTable2Mother.withOnlyEnSets(
 					"LDK2-ENS01; Legendary Decks II; Ultra Rare"
-				),
-				expectedPrint("LDK2-ENS01", "ultra rare", Language.EN)
+				)
 			),
 			// K-Series
 			Arguments.of(
-				CardTable2Mother.withOnlyEnSets("TLM-EN035K; ; Ultra Rare"),
-				expectedPrint("TLM-EN035K", "ultra rare", Language.EN)
+				PrintMother.kSeriesOf(
+					"TLM-EN035K",
+					"TLM",
+					35,
+					"ultra rare",
+					Language.EN,
+					Region.EN
+				),
+				CardTable2Mother.withOnlyEnSets("TLM-EN035K; ; Ultra Rare")
 			)
 		);
 	}
@@ -104,8 +120,8 @@ class YugipediaPrintMapperUnitTest {
 	@ParameterizedTest
 	@MethodSource("printsToTest")
 	void given_singleEnPrint_when_mapToPrints_then_correctPrints(
-		final CardTable2 cardTable2,
-		final Print expected
+		final Print expected,
+		final CardTable2 cardTable2
 	) {
 		// given - params
 		// when
@@ -145,7 +161,14 @@ class YugipediaPrintMapperUnitTest {
 		// when
 		final List<Print> actual = MAPPER.mapToPrints(cardTable2);
 		// then
-		final Print expectedPrint = expectedPrint("MS-EN001", "rare", Language.EN);
+		final Print expectedPrint = PrintMother.of(
+			"MS-EN001",
+			"MS",
+			1,
+			"rare",
+			Language.EN,
+			Region.EN
+		);
 		assertThat(actual).singleElement().isEqualTo(expectedPrint);
 	}
 }

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapperUnitTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapperUnitTest.java
@@ -46,7 +46,7 @@ class YugipediaPrintMapperUnitTest {
 			),
 			// single letter (for some localization)
 			Arguments.of(
-				 PrintMother.of(
+				PrintMother.of(
 					"BIP-S001",
 					"BIP",
 					1,

--- a/tools/src/test/java/io/github/ygojson/tools/test/PrintMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/test/PrintMother.java
@@ -1,0 +1,93 @@
+package io.github.ygojson.tools.test;
+
+import io.github.ygojson.model.data.Print;
+import io.github.ygojson.model.data.definition.localization.Language;
+import io.github.ygojson.model.data.definition.localization.Region;
+
+/**
+ * Mother for {@link Print} test data.
+ */
+public class PrintMother {
+
+	private PrintMother() {
+		// cannot be instantiated - mother class
+	}
+
+	/**
+	 * Creates a {@link Print}.
+	 */
+	public static Print of(
+		final String cardNumber,
+		final String setCode,
+		final Integer printNumber,
+		final String rarity,
+		final Language language,
+		final Region region
+	) {
+		final Print print = new Print();
+		print.setPrintCode(cardNumber);
+		print.setRarity(rarity);
+		print.setLanguage(language);
+		return print;
+	}
+
+	/**
+	 * Creates a first-series {@link Print}.
+	 */
+	public static Print firstSeriesOf(
+		final String setName,
+		final String rarity,
+		final Language language
+	) {
+		final Print print = new Print();
+		print.setFirstSeriesSet(setName);
+		print.setRarity(rarity);
+		print.setLanguage(language);
+		return print;
+	}
+
+	/**
+	 * Creates a special {@link Print}.
+	 */
+	public static Print specialOf(
+		final String cardNumber,
+		final String setCode,
+		final String printPrefix,
+		final Integer printNumber,
+		final String rarity,
+		final Language language,
+		final Region region
+	) {
+		final Print print = of(
+			cardNumber,
+			setCode,
+			printNumber,
+			rarity,
+			language,
+			region
+		);
+		return print;
+	}
+
+	/**
+	 * Creates a K-series {@link Print}.
+	 */
+	public static Print kSeriesOf(
+		final String cardNumber,
+		final String setCode,
+		final Integer printNumber,
+		final String rarity,
+		final Language language,
+		final Region region
+	) {
+		final Print print = of(
+			cardNumber,
+			setCode,
+			printNumber,
+			rarity,
+			language,
+			region
+		);
+		return print;
+	}
+}


### PR DESCRIPTION
- Add PrintMother to simplify test-model refactors
- Use PrintMother on YugipediaPrintMapperUnitTest

Part of #55 - prepare testing to support the split of the different fields