### PR TITLE
Handle CardNumber unreleased data

### DIFF
--- a/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapper.java
+++ b/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapper.java
@@ -42,8 +42,8 @@ public abstract class CardNumberMapper {
 		GeneralMapper.class
 	);
 
-	@Named("unknownToNull")
-	protected String mapUnknownToNull(final String value) {
+	@Named("unreleasedToNull")
+	protected String mapUnreleasedToNull(final String value) {
 		final String mappedValue = generalMapper.mapBlankStringToNull(value);
 		if (mappedValue != null && mappedValue.contains("?")) {
 			return null;
@@ -54,29 +54,29 @@ public abstract class CardNumberMapper {
 	@Mapping(
 		target = "stringValue",
 		source = "stringValue",
-		qualifiedByName = "unknownToNull"
+		qualifiedByName = "unreleasedToNull"
 	)
 	@Mapping(
 		target = "setCode",
 		source = "setCode",
-		qualifiedByName = "unknownToNull"
+		qualifiedByName = "unreleasedToNull"
 	)
 	@Mapping(
 		target = "printNumberPrefix",
 		source = "printNumberPrefix",
-		qualifiedByName = "unknownToNull"
+		qualifiedByName = "unreleasedToNull"
 	)
 	@Mapping(
 		target = "printNumberSuffix",
 		source = "printNumberSuffix",
-		qualifiedByName = "unknownToNull"
+		qualifiedByName = "unreleasedToNull"
 	)
-	protected abstract CardNumber copyWithoutUnknowns(
+	protected abstract CardNumber copyWithoutUnreleasedFields(
 		final CardNumber cardNumber
 	);
 
 	@Mapping(target = "printNumber", ignore = true)
-	protected abstract CardNumber mapWithUnknownPrintNumber(
+	protected abstract CardNumber mapWithUnreleasedPrintNumber(
 		final CardNumber cardNumber
 	);
 
@@ -88,12 +88,11 @@ public abstract class CardNumberMapper {
 		if (originalCardNumber.equals(updatedCardNumber)) {
 			return originalCardNumber;
 		}
-		// this indicates an unknown print/set
+		// this indicates an unreleased print/set
 		if (updatedCardNumber.stringValue() == null) {
-			// TODO: mark somehow the CardNumber
 			final Integer printNumber = updatedCardNumber.printNumber();
 			if (printNumber != null && printNumber == 0) {
-				return mapWithUnknownPrintNumber(updatedCardNumber);
+				return mapWithUnreleasedPrintNumber(updatedCardNumber);
 			}
 		}
 		return updatedCardNumber;
@@ -112,7 +111,7 @@ public abstract class CardNumberMapper {
 		final YugipediaLanguageRegion region
 	) {
 		final CardNumber cardNumber = mapInternalToCardNumber(setPrefix, region);
-		return copyWithoutUnknowns(cardNumber);
+		return copyWithoutUnreleasedFields(cardNumber);
 	}
 
 	private CardNumber mapInternalToCardNumber(
@@ -188,7 +187,7 @@ public abstract class CardNumberMapper {
 			generalMapper.mapToNullableInteger(number),
 			generalMapper.mapBlankStringToNull(suffix)
 		);
-		return copyWithoutUnknowns(mapped);
+		return copyWithoutUnreleasedFields(mapped);
 	}
 
 	private static Region toRegionCode(

--- a/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapper.java
+++ b/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapper.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
 
 import io.github.ygojson.model.data.Print;
 import io.github.ygojson.model.data.definition.localization.Language;
@@ -33,7 +34,9 @@ public abstract class YugipediaPrintMapper {
 	// 3rd field: rarity list
 	private static final int RARITY_LIST_FIELD = 2;
 
-	private final CardNumberMapper cardNumberMapper = new CardNumberMapper();
+	private final CardNumberMapper cardNumberMapper = Mappers.getMapper(
+		CardNumberMapper.class
+	);
 
 	/**
 	 * Maps to the YGOJSON Print model the yugipedia relevant information.

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapperUnitTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapperUnitTest.java
@@ -69,6 +69,41 @@ class CardNumberMapperUnitTest {
 			.isEqualTo(new CardNumber(printCode, "AAAA", Region.EN, "SP", 0, "S"));
 	}
 
+	private static Stream<Arguments> unknownPrintCodes() {
+		return Stream.of(
+			Arguments.of(
+				CardNumberMother.ofUnknownPrintNumber("???-EN???", Region.EN, null),
+				"???-EN???",
+				YugipediaLanguageRegion.EN
+			),
+			Arguments.of(
+				CardNumberMother.ofUnknownSetCode("????-JP001", Region.JP, 1),
+				"????-JP001",
+				YugipediaLanguageRegion.JP
+			),
+			Arguments.of(
+				CardNumberMother.ofUnknownPrintNumber("STP7-EN0??", Region.EN, "STP7"),
+				"STP7-EN0??",
+				YugipediaLanguageRegion.EN
+			)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("unknownPrintCodes")
+	void given_unknownPrintCode_when_mapPrintCodeToCardNumber_then_cardNumberNone() {
+		// given
+		final String printCode = "????-EN???"; // format of unknown printCode in Yugipedia
+		// when
+		final CardNumber actual = MAPPER.mapPrintCodeToCardNumber(
+			printCode,
+			YugipediaLanguageRegion.EN
+		);
+		// then
+		assertThat(actual)
+			.isEqualTo(new CardNumber(printCode, null, null, null, null, null));
+	}
+
 	static Stream<Arguments> printCodes() {
 		return Stream.of(
 			// Series 1 have its onw test cause it provides a CardNumber.NONE

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapperUnitTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapperUnitTest.java
@@ -69,20 +69,20 @@ class CardNumberMapperUnitTest {
 			.isEqualTo(new CardNumber(printCode, "AAAA", Region.EN, "SP", 0, "S"));
 	}
 
-	private static Stream<Arguments> unknownPrintCodes() {
+	private static Stream<Arguments> unreleasedPrintCodes() {
 		return Stream.of(
 			Arguments.of(
-				CardNumberMother.ofUnknownPrintNumber(Region.EN, null),
+				CardNumberMother.ofUnreleasedPrintNumber(Region.EN, null),
 				"???-EN???",
 				YugipediaLanguageRegion.EN
 			),
 			Arguments.of(
-				CardNumberMother.ofUnknownSetCode(Region.JP, 1),
+				CardNumberMother.ofUnreleasedSetCode(Region.JP, 1),
 				"????-JP001",
 				YugipediaLanguageRegion.JP
 			),
 			Arguments.of(
-				CardNumberMother.ofUnknownPrintNumber(Region.EN, "STP7"),
+				CardNumberMother.ofUnreleasedPrintNumber(Region.EN, "STP7"),
 				"STP7-EN0??",
 				YugipediaLanguageRegion.EN
 			)
@@ -90,8 +90,8 @@ class CardNumberMapperUnitTest {
 	}
 
 	@ParameterizedTest
-	@MethodSource("unknownPrintCodes")
-	void given_unknownPrintCode_when_mapPrintCodeToCardNumber_then_cardNumberNone(
+	@MethodSource("unreleasedPrintCodes")
+	void given_unreleasedPrintCode_when_mapPrintCodeToCardNumber_then_cardNumberNone(
 		final CardNumber expected,
 		final String printCode,
 		final YugipediaLanguageRegion languageRegion

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapperUnitTest.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/CardNumberMapperUnitTest.java
@@ -72,17 +72,17 @@ class CardNumberMapperUnitTest {
 	private static Stream<Arguments> unknownPrintCodes() {
 		return Stream.of(
 			Arguments.of(
-				CardNumberMother.ofUnknownPrintNumber("???-EN???", Region.EN, null),
+				CardNumberMother.ofUnknownPrintNumber(Region.EN, null),
 				"???-EN???",
 				YugipediaLanguageRegion.EN
 			),
 			Arguments.of(
-				CardNumberMother.ofUnknownSetCode("????-JP001", Region.JP, 1),
+				CardNumberMother.ofUnknownSetCode(Region.JP, 1),
 				"????-JP001",
 				YugipediaLanguageRegion.JP
 			),
 			Arguments.of(
-				CardNumberMother.ofUnknownPrintNumber("STP7-EN0??", Region.EN, "STP7"),
+				CardNumberMother.ofUnknownPrintNumber(Region.EN, "STP7"),
 				"STP7-EN0??",
 				YugipediaLanguageRegion.EN
 			)
@@ -91,17 +91,19 @@ class CardNumberMapperUnitTest {
 
 	@ParameterizedTest
 	@MethodSource("unknownPrintCodes")
-	void given_unknownPrintCode_when_mapPrintCodeToCardNumber_then_cardNumberNone() {
-		// given
-		final String printCode = "????-EN???"; // format of unknown printCode in Yugipedia
+	void given_unknownPrintCode_when_mapPrintCodeToCardNumber_then_cardNumberNone(
+		final CardNumber expected,
+		final String printCode,
+		final YugipediaLanguageRegion languageRegion
+	) {
+		// given - params
 		// when
 		final CardNumber actual = MAPPER.mapPrintCodeToCardNumber(
 			printCode,
-			YugipediaLanguageRegion.EN
+			languageRegion
 		);
 		// then
-		assertThat(actual)
-			.isEqualTo(new CardNumber(printCode, null, null, null, null, null));
+		assertThat(actual).isEqualTo(expected);
 	}
 
 	static Stream<Arguments> printCodes() {

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/test/CardNumberMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/test/CardNumberMother.java
@@ -13,19 +13,17 @@ public class CardNumberMother {
 	}
 
 	public static CardNumber ofUnknownSetCode(
-		final String stringValue,
 		final Region region,
 		final Integer printNumber
 	) {
-		return new CardNumber(stringValue, null, region, null, printNumber, null);
+		return new CardNumber(null, null, region, null, printNumber, null);
 	}
 
 	public static CardNumber ofUnknownPrintNumber(
-		final String stringValue,
 		final Region region,
 		final String setCode
 	) {
-		return new CardNumber(stringValue, setCode, region, null, null, null);
+		return new CardNumber(null, setCode, region, null, null, null);
 	}
 
 	public static CardNumber ofPrefix(

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/test/CardNumberMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/test/CardNumberMother.java
@@ -12,14 +12,14 @@ public class CardNumberMother {
 		// cannot be instantiated - mother class
 	}
 
-	public static CardNumber ofUnknownSetCode(
+	public static CardNumber ofUnreleasedSetCode(
 		final Region region,
 		final Integer printNumber
 	) {
 		return new CardNumber(null, null, region, null, printNumber, null);
 	}
 
-	public static CardNumber ofUnknownPrintNumber(
+	public static CardNumber ofUnreleasedPrintNumber(
 		final Region region,
 		final String setCode
 	) {

--- a/tools/src/test/java/io/github/ygojson/tools/dataprovider/test/CardNumberMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/dataprovider/test/CardNumberMother.java
@@ -12,6 +12,22 @@ public class CardNumberMother {
 		// cannot be instantiated - mother class
 	}
 
+	public static CardNumber ofUnknownSetCode(
+		final String stringValue,
+		final Region region,
+		final Integer printNumber
+	) {
+		return new CardNumber(stringValue, null, region, null, printNumber, null);
+	}
+
+	public static CardNumber ofUnknownPrintNumber(
+		final String stringValue,
+		final Region region,
+		final String setCode
+	) {
+		return new CardNumber(stringValue, setCode, region, null, null, null);
+	}
+
 	public static CardNumber ofPrefix(
 		final String stringValue,
 		final String setCode,

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/undefined_atk_def.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/undefined_atk_def.approved.json
@@ -485,8 +485,6 @@
   "language" : "ja",
   "regionCode" : "JP"
 }, {
-  "printCode" : "????-JP001",
-  "setCode" : "????",
   "printNumber" : 1,
   "rarity" : "quarter century secret rare",
   "language" : "ja",


### PR DESCRIPTION
- First attempt to handle unreleased data (see #5)
- Add failing tests with expectations of what is an unreleased `CardNumber` string
- Fix the `CardNumberMapper` to handle the unreleased fields