### PR TITLE
Refine print schema (without handling)

### DIFF
--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Print.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testInlineDataSchemas.Print.approved.json
@@ -18,7 +18,16 @@
       "type" : "string",
       "pattern" : "[a-zA-Z0-9]+-[a-zA-Z0-9]+"
     },
-    "firstSeriesSet" : {
+    "setCode" : {
+      "type" : "string"
+    },
+    "printNumberSuffix" : {
+      "type" : "string"
+    },
+    "printNumber" : {
+      "type" : "integer"
+    },
+    "printNumberPrefix" : {
       "type" : "string"
     },
     "rarity" : {
@@ -28,6 +37,10 @@
     "language" : {
       "type" : "string",
       "enum" : [ "en", "de", "es", "fr", "it", "ja", "ko", "pt", "zh-Hans", "zh-Hant" ]
+    },
+    "regionCode" : {
+      "type" : "string",
+      "enum" : [ "EN", "E", "A", "F", "FR", "C", "G", "DE", "I", "IT", "P", "PT", "S", "SP", "JP", "JA", "AE", "K", "KR", "TC", "SC", "" ]
     }
   },
   "required" : [ "id", "cardId", "setId" ],

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Print.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/JsonSchemaGeneratorAcceptanceTest.testWithDefsDataSchemas.Print.approved.json
@@ -4,6 +4,10 @@
     "Language" : {
       "type" : "string",
       "enum" : [ "en", "de", "es", "fr", "it", "ja", "ko", "pt", "zh-Hans", "zh-Hant" ]
+    },
+    "Region" : {
+      "type" : "string",
+      "enum" : [ "EN", "E", "A", "F", "FR", "C", "G", "DE", "I", "IT", "P", "PT", "S", "SP", "JP", "JA", "AE", "K", "KR", "TC", "SC", "" ]
     }
   },
   "type" : "object",
@@ -24,7 +28,16 @@
       "type" : "string",
       "pattern" : "[a-zA-Z0-9]+-[a-zA-Z0-9]+"
     },
-    "firstSeriesSet" : {
+    "setCode" : {
+      "type" : "string"
+    },
+    "printNumberSuffix" : {
+      "type" : "string"
+    },
+    "printNumber" : {
+      "type" : "integer"
+    },
+    "printNumberPrefix" : {
       "type" : "string"
     },
     "rarity" : {
@@ -33,6 +46,9 @@
     },
     "language" : {
       "$ref" : "#/$defs/Language"
+    },
+    "regionCode" : {
+      "$ref" : "#/$defs/Region"
     }
   },
   "required" : [ "id", "cardId", "setId" ],

--- a/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Print.approved.json
+++ b/model-utils/src/test/resources/io/github/ygojson/model/utils/schema/acceptance/SerializationAcceptanceTest.testDataModelSerialization.Print.approved.json
@@ -3,7 +3,11 @@
   "cardId" : "a040ed69-8df0-3ab6-ad10-15c416785a25",
   "setId" : "e44cd828-48e0-30eb-b1fe-f77038269f5e",
   "printCode" : "PMPYLWRK",
-  "firstSeriesSet" : "MEOZGBOQAY",
-  "rarity" : "UFOJ",
-  "language" : "zh-Hans"
+  "setCode" : "MEOZGBOQAY",
+  "printNumberSuffix" : "UFOJ",
+  "printNumber" : 1059,
+  "printNumberPrefix" : "XGHP",
+  "rarity" : "EQRGFN",
+  "language" : "zh-Hant",
+  "regionCode" : "JA"
 }

--- a/model/src/main/resources/schema/print.schema.json
+++ b/model/src/main/resources/schema/print.schema.json
@@ -29,9 +29,23 @@
       "type": "string",
       "pattern": "[a-zA-Z0-9]+-[a-zA-Z0-9]+"
     },
-    "firstSeriesSet": {
-      "title": "Name of the Series 1 set associated to this Print",
-      "description": "Note that this is only present on Prints belonging to Series 1 sets, as printCode is not present on that case",
+    "setCode": {
+      "title": "Code, abbreviation or name of the Set this print belongs to",
+      "description": "Set code or abbreviation of the set\nNote that for cards without printCode, this is the name of the set (i.e., for Series 1)",
+      "type": "string"
+    },
+    "printNumberSuffix": {
+      "title": "Suffix for the printNumber",
+      "description": "For some sets, the printNumber might have a suffix (i.e., K-Series)",
+      "type": "string"
+    },
+    "printNumber": {
+      "title": "Print number, usually the order on the set",
+      "type": "integer"
+    },
+    "printNumberPrefix": {
+      "title": "Prefix for the printNumber",
+      "description": "Some sets include a prefix on the printNumber to indicate a sub-set.\nAlso, special editions and/or promotional cards have a prefix to indicate that they are not from the original set",
       "type": "string"
     },
     "rarity": {
@@ -40,7 +54,12 @@
       "pattern": "[a-z]+"
     },
     "language": {
+      "title": "Language of the print",
       "$ref": "language.schema.json"
+    },
+    "regionCode": {
+      "title": "Region code of the print",
+      "$ref": "region.schema.json"
     }
   },
   "required": [

--- a/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapper.java
+++ b/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapper.java
@@ -125,8 +125,12 @@ public abstract class YugipediaPrintMapper {
 		source = "cardNumber",
 		qualifiedByName = "blankStringToNull"
 	)
+	@Mapping(target = "printNumberSuffix", ignore = true)
+	@Mapping(target = "printNumber", ignore = true)
+	@Mapping(target = "printNumberPrefix", ignore = true)
+	@Mapping(target = "regionCode", ignore = true)
 	@Mapping(
-		target = "firstSeriesSet",
+		target = "setCode",
 		source = "setName",
 		conditionExpression = "java(info.isFirstSeries())"
 	)

--- a/tools/src/test/java/io/github/ygojson/tools/test/PrintMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/test/PrintMother.java
@@ -40,7 +40,7 @@ public class PrintMother {
 		final Language language
 	) {
 		final Print print = new Print();
-		print.setFirstSeriesSet(setName);
+		print.setSetCode(setName);
 		print.setRarity(rarity);
 		print.setLanguage(language);
 		return print;

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/counter_trap.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/counter_trap.approved.json
@@ -407,7 +407,7 @@
   "rarity" : "common",
   "language" : "it"
 }, {
-  "firstSeriesSet" : "Vol.6",
+  "setCode" : "Vol.6",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/fusion_non_effect_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/fusion_non_effect_monster.approved.json
@@ -211,15 +211,15 @@
   "rarity" : "secret rare",
   "language" : "it"
 }, {
-  "firstSeriesSet" : "Starter Box: Theatrical Release",
+  "setCode" : "Starter Box: Theatrical Release",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "Starter Box",
+  "setCode" : "Starter Box",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "Official Guide Starter Book promotional card",
+  "setCode" : "Official Guide Starter Book promotional card",
   "rarity" : "ultra secret rare",
   "language" : "ja"
 }, {

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/name_present.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/name_present.approved.json
@@ -63,7 +63,7 @@
   "rarity" : "common",
   "language" : "it"
 }, {
-  "firstSeriesSet" : "Vol.5",
+  "setCode" : "Vol.5",
   "rarity" : "common",
   "language" : "ja"
 }, {

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/normal_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/normal_monster.approved.json
@@ -263,7 +263,7 @@
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
-  "firstSeriesSet" : "Oversized Gift for 7000 People",
+  "setCode" : "Oversized Gift for 7000 People",
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
@@ -999,11 +999,11 @@
   "rarity" : "quarter century secret rare",
   "language" : "it"
 }, {
-  "firstSeriesSet" : "Vol.1",
+  "setCode" : "Vol.1",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "EX Starter Box",
+  "setCode" : "EX Starter Box",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
@@ -1115,7 +1115,7 @@
   "rarity" : "millennium rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "20th Anniversary Duelist Box",
+  "setCode" : "20th Anniversary Duelist Box",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
@@ -1183,7 +1183,7 @@
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "\"Dark Magician\" Special Card",
+  "setCode" : "\"Dark Magician\" Special Card",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
@@ -1463,7 +1463,7 @@
   "rarity" : "prismatic secret rare",
   "language" : "zh-Hans"
 }, {
-  "firstSeriesSet" : "\"Dark Magician\" Giveaway for 1000 People!",
+  "setCode" : "\"Dark Magician\" Giveaway for 1000 People!",
   "rarity" : "ultra rare",
   "language" : "zh-Hant"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/spell.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/spell.approved.json
@@ -687,11 +687,11 @@
   "rarity" : "common",
   "language" : "it"
 }, {
-  "firstSeriesSet" : "Vol.1",
+  "setCode" : "Vol.1",
   "rarity" : "super rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "EX Starter Box",
+  "setCode" : "EX Starter Box",
   "rarity" : "common",
   "language" : "ja"
 }, {

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/trap.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/trap.approved.json
@@ -543,11 +543,11 @@
   "rarity" : "super rare",
   "language" : "it"
 }, {
-  "firstSeriesSet" : "Vol.1",
+  "setCode" : "Vol.1",
   "rarity" : "super rare",
   "language" : "ja"
 }, {
-  "firstSeriesSet" : "EX Starter Box",
+  "setCode" : "EX Starter Box",
   "rarity" : "common",
   "language" : "ja"
 }, {


### PR DESCRIPTION
- Refine the print-schema
- Handle only `firstSeriesSet` as the newly added `setCode`
- Fix compilation and tests