### PR TITLE
Populate print new model with YugipediaPrintMapper

### DIFF
--- a/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapper.java
+++ b/tools/src/main/java/io/github/ygojson/tools/dataprovider/impl/yugipedia/mapper/YugipediaPrintMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.ReportingPolicy;
 
 import io.github.ygojson.model.data.Print;
 import io.github.ygojson.model.data.definition.localization.Language;
+import io.github.ygojson.tools.dataprovider.impl.yugipedia.model.CardNumber;
 import io.github.ygojson.tools.dataprovider.impl.yugipedia.model.YugipediaLanguageRegion;
 import io.github.ygojson.tools.dataprovider.impl.yugipedia.model.wikitext.CardTable2;
 import io.github.ygojson.tools.dataprovider.impl.yugipedia.model.wikitext.MarkupString;
@@ -31,6 +32,8 @@ public abstract class YugipediaPrintMapper {
 	private static final int SET_NAME_FIELD = 1;
 	// 3rd field: rarity list
 	private static final int RARITY_LIST_FIELD = 2;
+
+	private final CardNumberMapper cardNumberMapper = new CardNumberMapper();
 
 	/**
 	 * Maps to the YGOJSON Print model the yugipedia relevant information.
@@ -84,60 +87,51 @@ public abstract class YugipediaPrintMapper {
 				"Expected at least 3 fields per card-set print but found: " + fields
 			);
 		}
-		final String cardNumber = fields.get(CARD_NUMBER_FIELD).toString();
+		final String cardNumberString = fields.get(CARD_NUMBER_FIELD).toString();
 		final String setName = fields.get(SET_NAME_FIELD).toString();
 		final Stream<MarkupString> rarities = fields
 			.get(RARITY_LIST_FIELD)
 			.splitByComma();
 		final Language language = langRegion.getLanguage();
-
-		return rarities
-			.map(rarity ->
-				new PrintInfo(cardNumber, setName, language, rarity.toString())
-			)
-			.map(this::mapPrint);
-	}
-
-	/**
-	 * Container to store the relevant information about the card print from {@link CardTable2}.
-	 *
-	 * @param cardNumber card number printed on the card
-	 * @param setName the name of the set
-	 * @param language the language of the card
-	 * @param rarity the rarity of the card
-	 */
-	protected record PrintInfo(
-		String cardNumber,
-		String setName,
-		Language language,
-		String rarity
-	) {
-		boolean isFirstSeries() {
-			return cardNumber == null || cardNumber.isBlank();
+		// card without known print-number
+		final CardNumber cardNumber;
+		if (cardNumberString == null || cardNumberString.isBlank()) {
+			// in this case, the card-number is just having the code as the setName
+			cardNumber = new CardNumber(null, setName, null, null, null, null);
+		} else {
+			cardNumber =
+				cardNumberMapper.mapPrintCodeToCardNumber(cardNumberString, langRegion);
 		}
+
+		return rarities.map(rarity ->
+			mapToPrint(cardNumber, language, rarity.toString())
+		);
 	}
 
 	@Mapping(target = "id", ignore = true)
 	@Mapping(target = "cardId", ignore = true)
 	@Mapping(target = "setId", ignore = true)
+	@Mapping(target = "printCode", source = "cardNumber.stringValue")
+	@Mapping(target = "setCode", source = "cardNumber.setCode")
 	@Mapping(
-		target = "printCode",
-		source = "cardNumber",
-		qualifiedByName = "blankStringToNull"
+		target = "printNumberPrefix",
+		source = "cardNumber.printNumberPrefix"
 	)
-	@Mapping(target = "printNumberSuffix", ignore = true)
-	@Mapping(target = "printNumber", ignore = true)
-	@Mapping(target = "printNumberPrefix", ignore = true)
-	@Mapping(target = "regionCode", ignore = true)
+	@Mapping(target = "printNumber", source = "cardNumber.printNumber")
 	@Mapping(
-		target = "setCode",
-		source = "setName",
-		conditionExpression = "java(info.isFirstSeries())"
+		target = "printNumberSuffix",
+		source = "cardNumber.printNumberSuffix"
 	)
+	@Mapping(target = "regionCode", source = "cardNumber.regionCode")
+	@Mapping(target = "language", source = "language")
 	@Mapping(
 		target = "rarity",
 		source = "rarity",
 		qualifiedByName = "toLowerCase"
 	)
-	protected abstract Print mapPrint(final PrintInfo info);
+	protected abstract Print mapToPrint(
+		final CardNumber cardNumber,
+		final Language language,
+		final String rarity
+	);
 }

--- a/tools/src/test/java/io/github/ygojson/tools/test/PrintMother.java
+++ b/tools/src/test/java/io/github/ygojson/tools/test/PrintMother.java
@@ -26,8 +26,11 @@ public class PrintMother {
 	) {
 		final Print print = new Print();
 		print.setPrintCode(cardNumber);
+		print.setSetCode(setCode);
+		print.setPrintNumber(printNumber);
 		print.setRarity(rarity);
 		print.setLanguage(language);
+		print.setRegionCode(region);
 		return print;
 	}
 
@@ -66,6 +69,7 @@ public class PrintMother {
 			language,
 			region
 		);
+		print.setPrintNumberPrefix(printPrefix);
 		return print;
 	}
 
@@ -88,6 +92,7 @@ public class PrintMother {
 			language,
 			region
 		);
+		print.setPrintNumberSuffix("K");
 		return print;
 	}
 }

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/continuous_spell.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/continuous_spell.approved.json
@@ -1,205 +1,359 @@
 [ {
   "printCode" : "EOJ-EN047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDDE-EN028",
+  "setCode" : "SDDE",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "CP08-EN004",
+  "setCode" : "CP08",
+  "printNumber" : 4,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCGX-EN215",
+  "setCode" : "LCGX",
+  "printNumber" : 215,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RYMP-EN081",
+  "setCode" : "RYMP",
+  "printNumber" : 81,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DUSA-EN060",
+  "setCode" : "DUSA",
+  "printNumber" : 60,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BLMR-EN088",
+  "setCode" : "BLMR",
+  "printNumber" : 88,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DR04-EN227",
+  "setCode" : "DR04",
+  "printNumber" : 227,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "EOJ-AE047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "EOJ-DE047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDDE-DE028",
+  "setCode" : "SDDE",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "CP08-DE004",
+  "setCode" : "CP08",
+  "printNumber" : 4,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCGX-DE215",
+  "setCode" : "LCGX",
+  "printNumber" : 215,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RYMP-DE081",
+  "setCode" : "RYMP",
+  "printNumber" : 81,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DUSA-DE060",
+  "setCode" : "DUSA",
+  "printNumber" : 60,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BLMR-DE088",
+  "setCode" : "BLMR",
+  "printNumber" : 88,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "EOJ-SP047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDDE-SP028",
+  "setCode" : "SDDE",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RYMP-SP081",
+  "setCode" : "RYMP",
+  "printNumber" : 81,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DUSA-SP060",
+  "setCode" : "DUSA",
+  "printNumber" : 60,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BLMR-SP088",
+  "setCode" : "BLMR",
+  "printNumber" : 88,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "EOJ-FR047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDDE-FR028",
+  "setCode" : "SDDE",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "CP08-FR004",
+  "setCode" : "CP08",
+  "printNumber" : 4,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RYMP-FR081",
+  "setCode" : "RYMP",
+  "printNumber" : 81,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DUSA-FR060",
+  "setCode" : "DUSA",
+  "printNumber" : 60,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BLMR-FR088",
+  "setCode" : "BLMR",
+  "printNumber" : 88,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "EOJ-IT047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDDE-IT028",
+  "setCode" : "SDDE",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "CP08-IT004",
+  "setCode" : "CP08",
+  "printNumber" : 4,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCGX-IT215",
+  "setCode" : "LCGX",
+  "printNumber" : 215,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RYMP-IT081",
+  "setCode" : "RYMP",
+  "printNumber" : 81,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DUSA-IT060",
+  "setCode" : "DUSA",
+  "printNumber" : 60,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BLMR-IT088",
+  "setCode" : "BLMR",
+  "printNumber" : 88,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "EOJ-JP047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "EE04-JP227",
+  "setCode" : "EE04",
+  "printNumber" : 227,
   "rarity" : "rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD14-JP028",
+  "setCode" : "SD14",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20AP-JP035",
+  "setCode" : "20AP",
+  "printNumber" : 35,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "EOJ-KR047",
+  "setCode" : "EOJ",
+  "printNumber" : 47,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD14-KR028",
+  "setCode" : "SD14",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "HGP4-KR227",
+  "setCode" : "HGP4",
+  "printNumber" : 227,
   "rarity" : "rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "20AP-KR035",
+  "setCode" : "20AP",
+  "printNumber" : 35,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DUSA-PT060",
+  "setCode" : "DUSA",
+  "printNumber" : 60,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "BLMR-PT088",
+  "setCode" : "BLMR",
+  "printNumber" : 88,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "ST21-SCP15",
+  "setCode" : "ST21",
+  "printNumber" : 15,
+  "printNumberPrefix" : "P",
   "rarity" : "super rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC053",
+  "setCode" : "23RC",
+  "printNumber" : 53,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC053",
+  "setCode" : "23RC",
+  "printNumber" : 53,
   "rarity" : "ultimate rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC053",
+  "setCode" : "23RC",
+  "printNumber" : 53,
   "rarity" : "collector's rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC053",
+  "setCode" : "23RC",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC053",
+  "setCode" : "23RC",
+  "printNumber" : 53,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC053",
+  "setCode" : "23RC",
+  "printNumber" : 53,
   "rarity" : "quarter century secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/counter_trap.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/counter_trap.approved.json
@@ -1,629 +1,1096 @@
 [ {
   "printCode" : "MRD-EN127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DB2-EN073",
+  "setCode" : "DB2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "CP01-EN008",
+  "setCode" : "CP01",
+  "printNumber" : 8,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GLD2-EN044",
+  "setCode" : "GLD2",
+  "printNumber" : 44,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDLS-EN038",
+  "setCode" : "SDLS",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BP01-EN047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BP01-EN047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "starfoil rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GLD5-EN045",
+  "setCode" : "GLD5",
+  "printNumber" : 45,
   "rarity" : "ghost/gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCYW-EN152",
+  "setCode" : "LCYW",
+  "printNumber" : 152,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCJW-EN182",
+  "setCode" : "LCJW",
+  "printNumber" : 182,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BLRR-EN100",
+  "setCode" : "BLRR",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "OP12-EN003",
+  "setCode" : "OP12",
+  "printNumber" : 3,
   "rarity" : "ultimate rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LART-EN014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SESL-EN045",
+  "setCode" : "SESL",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MAGO-EN051",
+  "setCode" : "MAGO",
+  "printNumber" : 51,
   "rarity" : "premium gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MAZE-EN063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MAZE-EN063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "collector's rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRD-EN127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SR14-EN038",
+  "setCode" : "SR14",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRD-127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
   "printCode" : "DLG1-EN046",
+  "setCode" : "DLG1",
+  "printNumber" : 46,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRD-E127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "RP01-EN045",
+  "setCode" : "RP01",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDID-AE039",
+  "setCode" : "SDID",
+  "printNumber" : 39,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "MRD-G127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "DB2-DE073",
+  "setCode" : "DB2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "CP01-DE008",
+  "setCode" : "CP01",
+  "printNumber" : 8,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RP01-DE045",
+  "setCode" : "RP01",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GLD2-DE044",
+  "setCode" : "GLD2",
+  "printNumber" : 44,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDLS-DE038",
+  "setCode" : "SDLS",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BP01-DE047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BP01-DE047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "starfoil rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GLD5-DE045",
+  "setCode" : "GLD5",
+  "printNumber" : 45,
   "rarity" : "ghost/gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCYW-DE152",
+  "setCode" : "LCYW",
+  "printNumber" : 152,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCJW-DE182",
+  "setCode" : "LCJW",
+  "printNumber" : 182,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BLRR-DE100",
+  "setCode" : "BLRR",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "OP12-DE003",
+  "setCode" : "OP12",
+  "printNumber" : 3,
   "rarity" : "ultimate rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LART-DE014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SESL-DE045",
+  "setCode" : "SESL",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MAGO-DE051",
+  "setCode" : "MAGO",
+  "printNumber" : 51,
   "rarity" : "premium gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MAZE-DE063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MAZE-DE063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "collector's rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MRD-DE127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SR14-DE038",
+  "setCode" : "SR14",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "PMT-S127",
+  "setCode" : "PMT",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "DB2-SP073",
+  "setCode" : "DB2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GLD2-SP044",
+  "setCode" : "GLD2",
+  "printNumber" : 44,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDLS-SP038",
+  "setCode" : "SDLS",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BP01-SP047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BP01-SP047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "starfoil rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GLD5-SP045",
+  "setCode" : "GLD5",
+  "printNumber" : 45,
   "rarity" : "ghost/gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCYW-SP152",
+  "setCode" : "LCYW",
+  "printNumber" : 152,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCJW-SP182",
+  "setCode" : "LCJW",
+  "printNumber" : 182,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BLRR-SP100",
+  "setCode" : "BLRR",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "OP12-SP003",
+  "setCode" : "OP12",
+  "printNumber" : 3,
   "rarity" : "ultimate rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LART-SP014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SESL-SP045",
+  "setCode" : "SESL",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MAGO-SP051",
+  "setCode" : "MAGO",
+  "printNumber" : 51,
   "rarity" : "premium gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MAZE-SP063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MAZE-SP063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "collector's rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MRD-SP127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SR14-SP038",
+  "setCode" : "SR14",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MRD-F127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DB2-FR073",
+  "setCode" : "DB2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "CP01-FR008",
+  "setCode" : "CP01",
+  "printNumber" : 8,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RP01-FR045",
+  "setCode" : "RP01",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GLD2-FR044",
+  "setCode" : "GLD2",
+  "printNumber" : 44,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDLS-FR038",
+  "setCode" : "SDLS",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BP01-FR047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BP01-FR047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "starfoil rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GLD5-FR045",
+  "setCode" : "GLD5",
+  "printNumber" : 45,
   "rarity" : "ghost/gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCYW-FR152",
+  "setCode" : "LCYW",
+  "printNumber" : 152,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCJW-FR182",
+  "setCode" : "LCJW",
+  "printNumber" : 182,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BLRR-FR100",
+  "setCode" : "BLRR",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "OP12-FR003",
+  "setCode" : "OP12",
+  "printNumber" : 3,
   "rarity" : "ultimate rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LART-FR014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SESL-FR045",
+  "setCode" : "SESL",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MAGO-FR051",
+  "setCode" : "MAGO",
+  "printNumber" : 51,
   "rarity" : "premium gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MAZE-FR063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MAZE-FR063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "collector's rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MRD-FR127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SR14-FR038",
+  "setCode" : "SR14",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "PMT-I127",
+  "setCode" : "PMT",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "DB2-IT073",
+  "setCode" : "DB2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "CP01-IT008",
+  "setCode" : "CP01",
+  "printNumber" : 8,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RP01-IT045",
+  "setCode" : "RP01",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GLD2-IT044",
+  "setCode" : "GLD2",
+  "printNumber" : 44,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDLS-IT038",
+  "setCode" : "SDLS",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BP01-IT047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BP01-IT047",
+  "setCode" : "BP01",
+  "printNumber" : 47,
   "rarity" : "starfoil rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GLD5-IT045",
+  "setCode" : "GLD5",
+  "printNumber" : 45,
   "rarity" : "ghost/gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCYW-IT152",
+  "setCode" : "LCYW",
+  "printNumber" : 152,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCJW-IT182",
+  "setCode" : "LCJW",
+  "printNumber" : 182,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BLRR-IT100",
+  "setCode" : "BLRR",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "OP12-IT003",
+  "setCode" : "OP12",
+  "printNumber" : 3,
   "rarity" : "ultimate rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LART-IT014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SESL-IT045",
+  "setCode" : "SESL",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MAGO-IT051",
+  "setCode" : "MAGO",
+  "printNumber" : 51,
   "rarity" : "premium gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MAZE-IT063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MAZE-IT063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "collector's rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MRD-IT127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SR14-IT038",
+  "setCode" : "SR14",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "setCode" : "Vol.6",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "ME-66",
+  "setCode" : "ME",
+  "printNumber" : 66,
   "rarity" : "super rare",
   "language" : "ja"
 }, {
   "printCode" : "DL4-056",
+  "setCode" : "DL4",
+  "printNumber" : 56,
   "rarity" : "super rare",
   "language" : "ja"
 }, {
   "printCode" : "BE2-JP073",
+  "setCode" : "BE2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD11-JP032",
+  "setCode" : "SD11",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD14-JP034",
+  "setCode" : "SD14",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS02-JP018",
+  "setCode" : "GS02",
+  "printNumber" : 18,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS02-JP018",
+  "setCode" : "GS02",
+  "printNumber" : 18,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD20-JP038",
+  "setCode" : "SD20",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BE02-JP057",
+  "setCode" : "BE02",
+  "printNumber" : 57,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GDB1-JP038",
+  "setCode" : "GDB1",
+  "printNumber" : 38,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD28-JP039",
+  "setCode" : "SD28",
+  "printNumber" : 39,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GP16-JP019",
+  "setCode" : "GP16",
+  "printNumber" : 19,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GP16-JP019",
+  "setCode" : "GP16",
+  "printNumber" : 19,
   "rarity" : "gold secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SR05-JP037",
+  "setCode" : "SR05",
+  "printNumber" : 37,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPC95",
+  "setCode" : "20TH",
+  "printNumber" : 95,
+  "printNumberPrefix" : "C",
   "rarity" : "super parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPC95",
+  "setCode" : "20TH",
+  "printNumber" : 95,
+  "printNumberPrefix" : "C",
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DBSS-JP045",
+  "setCode" : "DBSS",
+  "printNumber" : 45,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DBSS-JP045",
+  "setCode" : "DBSS",
+  "printNumber" : 45,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MRD-K127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "BP2-KR073",
+  "setCode" : "BP2",
+  "printNumber" : 73,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD14-KR034",
+  "setCode" : "SD14",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS02-KR018",
+  "setCode" : "GS02",
+  "printNumber" : 18,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS02-KR018",
+  "setCode" : "GS02",
+  "printNumber" : 18,
   "rarity" : "gold rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD20-KR038",
+  "setCode" : "SD20",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "AE01-KR004",
+  "setCode" : "AE01",
+  "printNumber" : 4,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD28-KR039",
+  "setCode" : "SD28",
+  "printNumber" : 39,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SR05-KR037",
+  "setCode" : "SR05",
+  "printNumber" : 37,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LEC1-KR095",
+  "setCode" : "LEC1",
+  "printNumber" : 95,
   "rarity" : "super parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LEC1-KR095",
+  "setCode" : "LEC1",
+  "printNumber" : 95,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DBSS-KR045",
+  "setCode" : "DBSS",
+  "printNumber" : 45,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DBSS-KR045",
+  "setCode" : "DBSS",
+  "printNumber" : 45,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LART-KR014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PMT-P127",
+  "setCode" : "PMT",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "LCJW-PT182",
+  "setCode" : "LCJW",
+  "printNumber" : 182,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "BLRR-PT100",
+  "setCode" : "BLRR",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "OP12-PT003",
+  "setCode" : "OP12",
+  "printNumber" : 3,
   "rarity" : "ultimate rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LART-PT014",
+  "setCode" : "LART",
+  "printNumber" : 14,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SESL-PT045",
+  "setCode" : "SESL",
+  "printNumber" : 45,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MAGO-PT051",
+  "setCode" : "MAGO",
+  "printNumber" : 51,
   "rarity" : "premium gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MAZE-PT063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MAZE-PT063",
+  "setCode" : "MAZE",
+  "printNumber" : 63,
   "rarity" : "collector's rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MRD-PT127",
+  "setCode" : "MRD",
+  "printNumber" : 127,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SR14-PT038",
+  "setCode" : "SR14",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "ST20-SC031",
+  "setCode" : "ST20",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "DBSS-SC045",
+  "setCode" : "DBSS",
+  "printNumber" : 45,
   "rarity" : "common",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "DBSS-SC045",
+  "setCode" : "DBSS",
+  "printNumber" : 45,
   "rarity" : "normal parallel rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "SD28-SC040",
+  "setCode" : "SD28",
+  "printNumber" : 40,
   "rarity" : "common",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC071",
+  "setCode" : "23RC",
+  "printNumber" : 71,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC071",
+  "setCode" : "23RC",
+  "printNumber" : 71,
   "rarity" : "ultimate rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC071",
+  "setCode" : "23RC",
+  "printNumber" : 71,
   "rarity" : "collector's rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC071",
+  "setCode" : "23RC",
+  "printNumber" : 71,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC071",
+  "setCode" : "23RC",
+  "printNumber" : 71,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC071",
+  "setCode" : "23RC",
+  "printNumber" : 71,
   "rarity" : "quarter century secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "SP01-TC060",
+  "setCode" : "SP01",
+  "printNumber" : 60,
   "rarity" : "super rare",
-  "language" : "zh-Hant"
+  "language" : "zh-Hant",
+  "regionCode" : "TC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/effect_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/effect_monster.approved.json
@@ -1,653 +1,1144 @@
 [ {
   "printCode" : "MACR-EN036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCKC-EN080",
+  "setCode" : "LCKC",
+  "printNumber" : 80,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SHVA-EN047",
+  "setCode" : "SHVA",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDSB-EN019",
+  "setCode" : "SDSB",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DUPO-EN077",
+  "setCode" : "DUPO",
+  "printNumber" : 77,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DUDE-EN003",
+  "setCode" : "DUDE",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MAGO-EN011",
+  "setCode" : "MAGO",
+  "printNumber" : 11,
   "rarity" : "premium gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MP22-EN257",
+  "setCode" : "MP22",
+  "printNumber" : 257,
   "rarity" : "prismatic secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDCB-EN014",
+  "setCode" : "SDCB",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDBT-EN014",
+  "setCode" : "SDBT",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "platinum secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultimate rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "collector's rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MACR-DE036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCKC-DE080",
+  "setCode" : "LCKC",
+  "printNumber" : 80,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SHVA-DE047",
+  "setCode" : "SHVA",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDSB-DE019",
+  "setCode" : "SDSB",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DUPO-DE077",
+  "setCode" : "DUPO",
+  "printNumber" : 77,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DUDE-DE003",
+  "setCode" : "DUDE",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MAGO-DE011",
+  "setCode" : "MAGO",
+  "printNumber" : 11,
   "rarity" : "premium gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MP22-DE257",
+  "setCode" : "MP22",
+  "printNumber" : 257,
   "rarity" : "prismatic secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDCB-DE014",
+  "setCode" : "SDCB",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDBT-DE014",
+  "setCode" : "SDBT",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "platinum secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "quarter century secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultimate rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "collector's rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MACR-SP036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCKC-SP080",
+  "setCode" : "LCKC",
+  "printNumber" : 80,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SHVA-SP047",
+  "setCode" : "SHVA",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDSB-SP019",
+  "setCode" : "SDSB",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DUPO-SP077",
+  "setCode" : "DUPO",
+  "printNumber" : 77,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DUDE-SP003",
+  "setCode" : "DUDE",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MAGO-SP011",
+  "setCode" : "MAGO",
+  "printNumber" : 11,
   "rarity" : "premium gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MP22-SP257",
+  "setCode" : "MP22",
+  "printNumber" : 257,
   "rarity" : "prismatic secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDCB-SP014",
+  "setCode" : "SDCB",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDBT-SP014",
+  "setCode" : "SDBT",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "platinum secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "quarter century secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultimate rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "collector's rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MACR-FR036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCKC-FR080",
+  "setCode" : "LCKC",
+  "printNumber" : 80,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SHVA-FR047",
+  "setCode" : "SHVA",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDSB-FR019",
+  "setCode" : "SDSB",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DUPO-FR077",
+  "setCode" : "DUPO",
+  "printNumber" : 77,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DUDE-FR003",
+  "setCode" : "DUDE",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MAGO-FR011",
+  "setCode" : "MAGO",
+  "printNumber" : 11,
   "rarity" : "premium gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MP22-FR257",
+  "setCode" : "MP22",
+  "printNumber" : 257,
   "rarity" : "prismatic secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDCB-FR014",
+  "setCode" : "SDCB",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDBT-FR014",
+  "setCode" : "SDBT",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "platinum secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "quarter century secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultimate rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "collector's rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MACR-IT036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCKC-IT080",
+  "setCode" : "LCKC",
+  "printNumber" : 80,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SHVA-IT047",
+  "setCode" : "SHVA",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDSB-IT019",
+  "setCode" : "SDSB",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DUPO-IT077",
+  "setCode" : "DUPO",
+  "printNumber" : 77,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DUDE-IT003",
+  "setCode" : "DUDE",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MAGO-IT011",
+  "setCode" : "MAGO",
+  "printNumber" : 11,
   "rarity" : "premium gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MP22-IT257",
+  "setCode" : "MP22",
+  "printNumber" : 257,
   "rarity" : "prismatic secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDCB-IT014",
+  "setCode" : "SDCB",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDBT-IT014",
+  "setCode" : "SDBT",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "platinum secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "quarter century secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultimate rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "collector's rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MACR-JP036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MACR-JP036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC02-JP009",
+  "setCode" : "RC02",
+  "printNumber" : 9,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC02-JP009",
+  "setCode" : "RC02",
+  "printNumber" : 9,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC02-JP009",
+  "setCode" : "RC02",
+  "printNumber" : 9,
   "rarity" : "collector's rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD35-JP019",
+  "setCode" : "SD35",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPC85",
+  "setCode" : "20TH",
+  "printNumber" : 85,
+  "printNumberPrefix" : "C",
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPC85",
+  "setCode" : "20TH",
+  "printNumber" : 85,
+  "printNumberPrefix" : "C",
   "rarity" : "20th secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC03-JP010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC03-JP010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC03-JP010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "collector's rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC03-JP010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "premium gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP016",
+  "setCode" : "PAC1",
+  "printNumber" : 16,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP016",
+  "setCode" : "PAC1",
+  "printNumber" : 16,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP016",
+  "setCode" : "PAC1",
+  "printNumber" : 16,
   "rarity" : "prismatic secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD44-JP014",
+  "setCode" : "SD44",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "collector's rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "extra secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "quarter century secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "holographic rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MACR-KR036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "MACR-KR036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC02-KR009",
+  "setCode" : "RC02",
+  "printNumber" : 9,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC02-KR009",
+  "setCode" : "RC02",
+  "printNumber" : 9,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD35-KR019",
+  "setCode" : "SD35",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LEC1-KR085",
+  "setCode" : "LEC1",
+  "printNumber" : 85,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LEC1-KR085",
+  "setCode" : "LEC1",
+  "printNumber" : 85,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC03-KR010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC03-KR010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC03-KR010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC03-KR010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "prismatic secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR016",
+  "setCode" : "PAC1",
+  "printNumber" : 16,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR016",
+  "setCode" : "PAC1",
+  "printNumber" : 16,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR016",
+  "setCode" : "PAC1",
+  "printNumber" : 16,
   "rarity" : "prismatic secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD44-KR014",
+  "setCode" : "SD44",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "collector's rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "quarter century secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR009",
+  "setCode" : "RC04",
+  "printNumber" : 9,
   "rarity" : "hgr",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "MACR-PT036",
+  "setCode" : "MACR",
+  "printNumber" : 36,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LCKC-PT080",
+  "setCode" : "LCKC",
+  "printNumber" : 80,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SHVA-PT047",
+  "setCode" : "SHVA",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SDSB-PT019",
+  "setCode" : "SDSB",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DUPO-PT077",
+  "setCode" : "DUPO",
+  "printNumber" : 77,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DUDE-PT003",
+  "setCode" : "DUDE",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MAGO-PT011",
+  "setCode" : "MAGO",
+  "printNumber" : 11,
   "rarity" : "premium gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MP22-PT257",
+  "setCode" : "MP22",
+  "printNumber" : 257,
   "rarity" : "prismatic secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SDCB-PT014",
+  "setCode" : "SDCB",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SDBT-PT014",
+  "setCode" : "SDBT",
+  "printNumber" : 14,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "platinum secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "quarter century secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "ultimate rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT008",
+  "setCode" : "RA01",
+  "printNumber" : 8,
   "rarity" : "collector's rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SD35-SC019",
+  "setCode" : "SD35",
+  "printNumber" : 19,
   "rarity" : "common",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "RC03-SC010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "RC03-SC010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "RC03-SC010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "RC03-SC010",
+  "setCode" : "RC03",
+  "printNumber" : 10,
   "rarity" : "premium gold rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "22RC-SC009",
+  "setCode" : "22RC",
+  "printNumber" : 9,
   "rarity" : "ultimate rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "22RC-SC009",
+  "setCode" : "22RC",
+  "printNumber" : 9,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "22RC-SC009",
+  "setCode" : "22RC",
+  "printNumber" : 9,
   "rarity" : "collector's rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "TM02-SC097",
+  "setCode" : "TM02",
+  "printNumber" : 97,
   "rarity" : "rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "ultimate rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "collector's rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "quarter century secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC013",
+  "setCode" : "23RC",
+  "printNumber" : 13,
   "rarity" : "holographic rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/fusion_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/fusion_monster.approved.json
@@ -1,133 +1,232 @@
 [ {
   "printCode" : "BODE-EN039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "POTE-EN100",
+  "setCode" : "POTE",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MP22-EN209",
+  "setCode" : "MP22",
+  "printNumber" : 209,
   "rarity" : "prismatic secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BODE-DE039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "POTE-DE100",
+  "setCode" : "POTE",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MP22-DE209",
+  "setCode" : "MP22",
+  "printNumber" : 209,
   "rarity" : "prismatic secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BODE-SP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "POTE-SP100",
+  "setCode" : "POTE",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MP22-SP209",
+  "setCode" : "MP22",
+  "printNumber" : 209,
   "rarity" : "prismatic secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BODE-FR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "POTE-FR100",
+  "setCode" : "POTE",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MP22-FR209",
+  "setCode" : "MP22",
+  "printNumber" : 209,
   "rarity" : "prismatic secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BODE-IT039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "POTE-IT100",
+  "setCode" : "POTE",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MP22-IT209",
+  "setCode" : "MP22",
+  "printNumber" : 209,
   "rarity" : "prismatic secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BODE-JP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BODE-JP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BODE-JP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BODE-JP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "prismatic secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BODE-JP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BODE-JP039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "prismatic secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BODE-KR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BODE-KR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BODE-KR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BODE-KR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "prismatic secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BODE-KR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BODE-KR039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "prismatic secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BODE-PT039",
+  "setCode" : "BODE",
+  "printNumber" : 39,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "POTE-PT100",
+  "setCode" : "POTE",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MP22-PT209",
+  "setCode" : "MP22",
+  "printNumber" : 209,
   "rarity" : "prismatic secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MGP6-SC133",
+  "setCode" : "MGP6",
+  "printNumber" : 133,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "MGP6-SC133",
+  "setCode" : "MGP6",
+  "printNumber" : 133,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "MGP6-SC133",
+  "setCode" : "MGP6",
+  "printNumber" : 133,
   "rarity" : "prismatic secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/fusion_non_effect_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/fusion_non_effect_monster.approved.json
@@ -1,215 +1,386 @@
 [ {
   "printCode" : "DB1-EN100",
+  "setCode" : "DB1",
+  "printNumber" : 100,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCJW-EN053",
+  "setCode" : "LCJW",
+  "printNumber" : 53,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MIL1-EN038",
+  "setCode" : "MIL1",
+  "printNumber" : 38,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SS02-ENB20",
+  "setCode" : "SS02",
+  "printNumber" : 20,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SBC1-ENB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SBC1-ENB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
   "language" : "en"
 }, {
   "printCode" : "SDJ-024",
+  "setCode" : "SDJ",
+  "printNumber" : 24,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "DLG1-EN003",
+  "setCode" : "DLG1",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRL-E111",
+  "setCode" : "MRL",
+  "printNumber" : 111,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "RP01-EN002",
+  "setCode" : "RP01",
+  "printNumber" : 2,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-A003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "LOB-003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
   "language" : "en"
 }, {
   "printCode" : "SRL-G111",
+  "setCode" : "SRL",
+  "printNumber" : 111,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDJ-G024",
+  "setCode" : "SDJ",
+  "printNumber" : 24,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "DB1-DE100",
+  "setCode" : "DB1",
+  "printNumber" : 100,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RP01-DE002",
+  "setCode" : "RP01",
+  "printNumber" : 2,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCJW-DE053",
+  "setCode" : "LCJW",
+  "printNumber" : 53,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MIL1-DE038",
+  "setCode" : "MIL1",
+  "printNumber" : 38,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SS02-DEB20",
+  "setCode" : "SS02",
+  "printNumber" : 20,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LOB-DE003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SBC1-DEB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SBC1-DEB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LDD-S003",
+  "setCode" : "LDD",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIJ-S024",
+  "setCode" : "BIJ",
+  "printNumber" : 24,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "DB1-SP100",
+  "setCode" : "DB1",
+  "printNumber" : 100,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCJW-SP053",
+  "setCode" : "LCJW",
+  "printNumber" : 53,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MIL1-SP038",
+  "setCode" : "MIL1",
+  "printNumber" : 38,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SS02-SPB20",
+  "setCode" : "SS02",
+  "printNumber" : 20,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LOB-SP003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SBC1-SPB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SBC1-SPB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MDM-F111",
+  "setCode" : "MDM",
+  "printNumber" : 111,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDJ-F024",
+  "setCode" : "DDJ",
+  "printNumber" : 24,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "RP01-FR002",
+  "setCode" : "RP01",
+  "printNumber" : 2,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCJW-FR053",
+  "setCode" : "LCJW",
+  "printNumber" : 53,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MIL1-FR038",
+  "setCode" : "MIL1",
+  "printNumber" : 38,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SS02-FRB20",
+  "setCode" : "SS02",
+  "printNumber" : 20,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LOB-FR003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SBC1-FRB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SBC1-FRB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LDD-C003",
+  "setCode" : "LDD",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "SDM-I111",
+  "setCode" : "SDM",
+  "printNumber" : 111,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIJ-I024",
+  "setCode" : "MIJ",
+  "printNumber" : 24,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "RP01-IT002",
+  "setCode" : "RP01",
+  "printNumber" : 2,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCJW-IT053",
+  "setCode" : "LCJW",
+  "printNumber" : 53,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MIL1-IT038",
+  "setCode" : "MIL1",
+  "printNumber" : 38,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SS02-ITB20",
+  "setCode" : "SS02",
+  "printNumber" : 20,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LOB-IT003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SBC1-ITB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SBC1-ITB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "setCode" : "Starter Box: Theatrical Release",
   "rarity" : "ultra rare",
@@ -224,82 +395,148 @@
   "language" : "ja"
 }, {
   "printCode" : "LB-03",
+  "setCode" : "LB",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "DL2-003",
+  "setCode" : "DL2",
+  "printNumber" : 3,
   "rarity" : "rare",
   "language" : "ja"
 }, {
   "printCode" : "BE1-JP100",
+  "setCode" : "BE1",
+  "printNumber" : 100,
   "rarity" : "rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BE01-JP090",
+  "setCode" : "BE01",
+  "printNumber" : 90,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "15AX-JPM37",
+  "setCode" : "15AX",
+  "printNumber" : 37,
+  "printNumberPrefix" : "M",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "15AX-JPM37",
+  "setCode" : "15AX",
+  "printNumber" : 37,
+  "printNumberPrefix" : "M",
   "rarity" : "millennium rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LOB-K003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "BP1-KR100",
+  "setCode" : "BP1",
+  "printNumber" : 100,
   "rarity" : "rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SDJ-KR024",
+  "setCode" : "SDJ",
+  "printNumber" : 24,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AX-KRM37",
+  "setCode" : "15AX",
+  "printNumber" : 37,
+  "printNumberPrefix" : "M",
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AX-KRM37",
+  "setCode" : "15AX",
+  "printNumber" : 37,
+  "printNumberPrefix" : "M",
   "rarity" : "millennium rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LDB-P003",
+  "setCode" : "LDB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIJ-P024",
+  "setCode" : "DIJ",
+  "printNumber" : 24,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "LCJW-PT053",
+  "setCode" : "LCJW",
+  "printNumber" : 53,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MIL1-PT038",
+  "setCode" : "MIL1",
+  "printNumber" : 38,
   "rarity" : "rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SS02-PTB20",
+  "setCode" : "SS02",
+  "printNumber" : 20,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LOB-PT003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SBC1-PTB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SBC1-PTB22",
+  "setCode" : "SBC1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "B",
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "FRP1-SCA01",
+  "setCode" : "FRP1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "super parallel rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/link_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/link_monster.approved.json
@@ -1,385 +1,673 @@
 [ {
   "printCode" : "FLOD-EN047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MP19-EN028",
+  "setCode" : "MP19",
+  "printNumber" : 28,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GEIM-EN050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GEIM-EN050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MGED-EN034",
+  "setCode" : "MGED",
+  "printNumber" : 34,
   "rarity" : "premium gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "platinum secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultimate rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RA01-EN043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "collector's rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "FLOD-DE047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MP19-DE028",
+  "setCode" : "MP19",
+  "printNumber" : 28,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GEIM-DE050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GEIM-DE050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MGED-DE034",
+  "setCode" : "MGED",
+  "printNumber" : 34,
   "rarity" : "premium gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "platinum secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "quarter century secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultimate rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RA01-DE043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "collector's rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "FLOD-SP047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MP19-SP028",
+  "setCode" : "MP19",
+  "printNumber" : 28,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GEIM-SP050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GEIM-SP050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MGED-SP034",
+  "setCode" : "MGED",
+  "printNumber" : 34,
   "rarity" : "premium gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "platinum secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "quarter century secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultimate rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RA01-SP043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "collector's rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "FLOD-FR047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MP19-FR028",
+  "setCode" : "MP19",
+  "printNumber" : 28,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GEIM-FR050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GEIM-FR050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MGED-FR034",
+  "setCode" : "MGED",
+  "printNumber" : 34,
   "rarity" : "premium gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "platinum secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "quarter century secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultimate rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RA01-FR043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "collector's rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "FLOD-IT047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MP19-IT028",
+  "setCode" : "MP19",
+  "printNumber" : 28,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GEIM-IT050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GEIM-IT050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MGED-IT034",
+  "setCode" : "MGED",
+  "printNumber" : 34,
   "rarity" : "premium gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "platinum secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "quarter century secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultimate rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RA01-IT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "collector's rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "FLOD-JP047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "FLOD-JP047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "collector's rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "extra secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RC04-JP044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "quarter century secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "FLOD-KR047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "FLOD-KR047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "collector's rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RC04-KR044",
+  "setCode" : "RC04",
+  "printNumber" : 44,
   "rarity" : "quarter century secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "FLOD-PT047",
+  "setCode" : "FLOD",
+  "printNumber" : 47,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MP19-PT028",
+  "setCode" : "MP19",
+  "printNumber" : 28,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "GEIM-PT050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "GEIM-PT050",
+  "setCode" : "GEIM",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MGED-PT034",
+  "setCode" : "MGED",
+  "printNumber" : 34,
   "rarity" : "premium gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "platinum secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "quarter century secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "ultimate rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "RA01-PT043",
+  "setCode" : "RA01",
+  "printNumber" : 43,
   "rarity" : "collector's rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MGP2-SC029",
+  "setCode" : "MGP2",
+  "printNumber" : 29,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "MGP2-SC029",
+  "setCode" : "MGP2",
+  "printNumber" : 29,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC046",
+  "setCode" : "23RC",
+  "printNumber" : 46,
   "rarity" : "super rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC046",
+  "setCode" : "23RC",
+  "printNumber" : 46,
   "rarity" : "ultimate rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC046",
+  "setCode" : "23RC",
+  "printNumber" : 46,
   "rarity" : "collector's rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC046",
+  "setCode" : "23RC",
+  "printNumber" : 46,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC046",
+  "setCode" : "23RC",
+  "printNumber" : 46,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC046",
+  "setCode" : "23RC",
+  "printNumber" : 46,
   "rarity" : "quarter century secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/name_present.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/name_present.approved.json
@@ -1,97 +1,162 @@
 [ {
   "printCode" : "DB1-EN162",
+  "setCode" : "DB1",
+  "printNumber" : 162,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRD-EN035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRD-EN035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MRD-035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
   "language" : "en"
 }, {
   "printCode" : "MRD-E035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "MRD-035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
   "language" : "en"
 }, {
   "printCode" : "MRD-G035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "DB1-DE162",
+  "setCode" : "DB1",
+  "printNumber" : 162,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MRD-DE035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "PMT-S035",
+  "setCode" : "PMT",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "DB1-SP162",
+  "setCode" : "DB1",
+  "printNumber" : 162,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MRD-SP035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MRD-F035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "MRD-FR035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "PMT-I035",
+  "setCode" : "PMT",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MRD-IT035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "setCode" : "Vol.5",
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "RB-35",
+  "setCode" : "RB",
+  "printNumber" : 35,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "DL2-122",
+  "setCode" : "DL2",
+  "printNumber" : 122,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "BE1-JP162",
+  "setCode" : "BE1",
+  "printNumber" : 162,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MRD-K035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "BP1-KR162",
+  "setCode" : "BP1",
+  "printNumber" : 162,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PMT-P035",
+  "setCode" : "PMT",
+  "printNumber" : 35,
   "rarity" : "short print",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "MRD-PT035",
+  "setCode" : "MRD",
+  "printNumber" : 35,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/normal_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/normal_monster.approved.json
@@ -1,1003 +1,1802 @@
 [ {
   "printCode" : "SYE-001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
   "language" : "en"
 }, {
   "printCode" : "DB1-EN102",
+  "setCode" : "DB1",
+  "printNumber" : 102,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "FL1-EN002",
+  "setCode" : "FL1",
+  "printNumber" : 2,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SD6-EN003",
+  "setCode" : "SD6",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DPYG-EN001",
+  "setCode" : "DPYG",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LC01-EN005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DL11-EN001",
+  "setCode" : "DL11",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCYW-EN001",
+  "setCode" : "LCYW",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LC01-EN005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSYR-EN001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSYR-EN001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "ultimate rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DPBC-EN008",
+  "setCode" : "DPBC",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YGLD-ENA03",
+  "setCode" : "YGLD",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YGLD-ENC09",
+  "setCode" : "YGLD",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MVP1-EN054",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "CT13-EN003",
+  "setCode" : "CT13",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LDK2-ENY10",
+  "setCode" : "LDK2",
+  "printNumber" : 10,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDMY-EN010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MVP1-ENGV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "GV",
   "rarity" : "gold secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MVP1-ENG54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "G",
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DUSA-EN100",
+  "setCode" : "DUSA",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "CT14-EN001",
+  "setCode" : "CT14",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LEDD-ENA01",
+  "setCode" : "LEDD",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SS01-ENA01",
+  "setCode" : "SS01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DUPO-EN101",
+  "setCode" : "DUPO",
+  "printNumber" : 101,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "STP1-EN001",
+  "setCode" : "STP1",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MVP1-ENSV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SV",
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MVP1-ENS54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "S",
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SS04-ENA01",
+  "setCode" : "SS04",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MAGO-EN002",
+  "setCode" : "MAGO",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SBCB-EN001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SBCB-EN001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GFTP-EN128",
+  "setCode" : "GFTP",
+  "printNumber" : 128,
   "rarity" : "ghost rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "2021-EN001",
+  "setCode" : "2021",
+  "printNumber" : 1,
   "rarity" : "extra secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MGED-EN002",
+  "setCode" : "MGED",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "25TH-EN001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "HAC1-EN002",
+  "setCode" : "HAC1",
+  "printNumber" : 2,
   "rarity" : "duel terminal ultra parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "ADC1-EN001",
+  "setCode" : "ADC1",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LC01-EN005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LC01-EN005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SBC1-ENA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SBC1-ENA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TN23-EN001",
+  "setCode" : "TN23",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
   "printCode" : "DDS-002",
+  "setCode" : "DDS",
+  "printNumber" : 2,
   "rarity" : "prismatic secret rare",
   "language" : "en"
 }, {
   "printCode" : "SDY-006",
+  "setCode" : "SDY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
   "printCode" : "BPT-001",
+  "setCode" : "BPT",
+  "printNumber" : 1,
   "rarity" : "secret rare",
   "language" : "en"
 }, {
   "printCode" : "BPT-007",
+  "setCode" : "BPT",
+  "printNumber" : 7,
   "rarity" : "secret rare",
   "language" : "en"
 }, {
   "printCode" : "PCY-004",
+  "setCode" : "PCY",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
   "language" : "en"
 }, {
   "printCode" : "JUMP-EN049",
+  "setCode" : "JUMP",
+  "printNumber" : 49,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DTP1-EN002",
+  "setCode" : "DTP1",
+  "printNumber" : 2,
   "rarity" : "duel terminal rare parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DLG1-EN004",
+  "setCode" : "DLG1",
+  "printNumber" : 4,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DTP1-EN002",
+  "setCode" : "DTP1",
+  "printNumber" : 2,
   "rarity" : "duel terminal rare parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DT01-EN002",
+  "setCode" : "DT01",
+  "printNumber" : 2,
   "rarity" : "duel terminal rare parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "JMPS-EN003",
+  "setCode" : "JMPS",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YUCB-EN001",
+  "setCode" : "YUCB",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MVP1-ENSE3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SE",
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-E003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "SDY-E005",
+  "setCode" : "SDY",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "PCY-E004",
+  "setCode" : "PCY",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "RP01-EN003",
+  "setCode" : "RP01",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YUCB-EN001",
+  "setCode" : "YUCB",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-A005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "SDY-A006",
+  "setCode" : "SDY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "setCode" : "Oversized Gift for 7000 People",
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
   "printCode" : "LOB-005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
   "printCode" : "SDY-006",
+  "setCode" : "SDY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
   "language" : "en"
 }, {
   "printCode" : "2015-JPP02",
+  "setCode" : "2015",
+  "printNumber" : 2,
+  "printNumberPrefix" : "JPP",
   "rarity" : "millennium rare",
   "language" : "en"
 }, {
   "printCode" : "SDID-AE001",
+  "setCode" : "SDID",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "SDY-G005",
+  "setCode" : "SDY",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "LOB-G003",
+  "setCode" : "LOB",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "PCY-G004",
+  "setCode" : "PCY",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SYE-DE001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DB1-DE102",
+  "setCode" : "DB1",
+  "printNumber" : 102,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SD6-DE003",
+  "setCode" : "SD6",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RP01-DE003",
+  "setCode" : "RP01",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DPYG-DE001",
+  "setCode" : "DPYG",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LC01-DE005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DL11-DE001",
+  "setCode" : "DL11",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCYW-DE001",
+  "setCode" : "LCYW",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSYR-DE001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSYR-DE001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "ultimate rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YGLD-DEA03",
+  "setCode" : "YGLD",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YGLD-DEC09",
+  "setCode" : "YGLD",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DPBC-DE008",
+  "setCode" : "DPBC",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MVP1-DE054",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "CT13-DE003",
+  "setCode" : "CT13",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LDK2-DEY10",
+  "setCode" : "LDK2",
+  "printNumber" : 10,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDMY-DE010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MVP1-DEGV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "GV",
   "rarity" : "gold secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MVP1-DEG54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "G",
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DUSA-DE100",
+  "setCode" : "DUSA",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "CT14-DE001",
+  "setCode" : "CT14",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LEDD-DEA01",
+  "setCode" : "LEDD",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YUCB-DE001",
+  "setCode" : "YUCB",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LC01-DE005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SS01-DEA01",
+  "setCode" : "SS01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DUPO-DE101",
+  "setCode" : "DUPO",
+  "printNumber" : 101,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "STP1-DE001",
+  "setCode" : "STP1",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MVP1-DESV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SV",
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MVP1-DES54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "S",
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SS04-DEA01",
+  "setCode" : "SS04",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MAGO-DE002",
+  "setCode" : "MAGO",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SBCB-DE001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SBCB-DE001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GFTP-DE128",
+  "setCode" : "GFTP",
+  "printNumber" : 128,
   "rarity" : "ghost rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MGED-DE002",
+  "setCode" : "MGED",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "25TH-DE001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "HAC1-DE002",
+  "setCode" : "HAC1",
+  "printNumber" : 2,
   "rarity" : "duel terminal ultra parallel rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LC01-DE005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LC01-DE005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "quarter century secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LOB-DE005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SBC1-DEA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SBC1-DEA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "secret",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TN23-DE001",
+  "setCode" : "TN23",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BIY-S006",
+  "setCode" : "BIY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "LDD-S005",
+  "setCode" : "LDD",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "DL1-S002",
+  "setCode" : "DL1",
+  "printNumber" : 2,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "DOR-S002",
+  "setCode" : "DOR",
+  "printNumber" : 2,
   "rarity" : "prismatic secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "PCY-S004",
+  "setCode" : "PCY",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "SYE-SP001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DB1-SP102",
+  "setCode" : "DB1",
+  "printNumber" : 102,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DPYG-SP001",
+  "setCode" : "DPYG",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DL11-SP001",
+  "setCode" : "DL11",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCYW-SP001",
+  "setCode" : "LCYW",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSYR-SP001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSYR-SP001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "ultimate rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YGLD-SPA03",
+  "setCode" : "YGLD",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YGLD-SPC09",
+  "setCode" : "YGLD",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DPBC-SP008",
+  "setCode" : "DPBC",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MVP1-SP054",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "CT13-SP003",
+  "setCode" : "CT13",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LDK2-SPY10",
+  "setCode" : "LDK2",
+  "printNumber" : 10,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDMY-SP010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MVP1-SPGV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "GV",
   "rarity" : "gold secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MVP1-SPG54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "G",
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DUSA-SP100",
+  "setCode" : "DUSA",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "CT14-SP001",
+  "setCode" : "CT14",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LEDD-SPA01",
+  "setCode" : "LEDD",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SS01-SPA01",
+  "setCode" : "SS01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DUPO-SP101",
+  "setCode" : "DUPO",
+  "printNumber" : 101,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "STP1-SP001",
+  "setCode" : "STP1",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MVP1-SPSV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SV",
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MVP1-SPS54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "S",
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SS04-SPA01",
+  "setCode" : "SS04",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MAGO-SP002",
+  "setCode" : "MAGO",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SBCB-SP001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SBCB-SP001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GFTP-SP128",
+  "setCode" : "GFTP",
+  "printNumber" : 128,
   "rarity" : "ghost rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MGED-SP002",
+  "setCode" : "MGED",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "25TH-SP001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "HAC1-SP002",
+  "setCode" : "HAC1",
+  "printNumber" : 2,
   "rarity" : "duel terminal ultra parallel rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LC01-SP005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LC01-SP005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "quarter century secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LOB-SP005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SBC1-SPA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SBC1-SPA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TN23-SP001",
+  "setCode" : "TN23",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DDY-F005",
+  "setCode" : "DDY",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "LDD-F003",
+  "setCode" : "LDD",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "PCY-F004",
+  "setCode" : "PCY",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "SYE-FR001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SD6-FR003",
+  "setCode" : "SD6",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RP01-FR003",
+  "setCode" : "RP01",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DPYG-FR001",
+  "setCode" : "DPYG",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DL11-FR001",
+  "setCode" : "DL11",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCYW-FR001",
+  "setCode" : "LCYW",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSYR-FR001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSYR-FR001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "ultimate rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YGLD-FRA03",
+  "setCode" : "YGLD",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YGLD-FRC09",
+  "setCode" : "YGLD",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DPBC-FR008",
+  "setCode" : "DPBC",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MVP1-FR054",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "CT13-FR003",
+  "setCode" : "CT13",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LDK2-FRY10",
+  "setCode" : "LDK2",
+  "printNumber" : 10,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDMY-FR010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MVP1-FRGV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "GV",
   "rarity" : "gold secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MVP1-FRG54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "G",
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DUSA-FR100",
+  "setCode" : "DUSA",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "CT14-FR001",
+  "setCode" : "CT14",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LEDD-FRA01",
+  "setCode" : "LEDD",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YUCB-FR001",
+  "setCode" : "YUCB",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SS01-FRA01",
+  "setCode" : "SS01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DUPO-FR101",
+  "setCode" : "DUPO",
+  "printNumber" : 101,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "STP1-FR001",
+  "setCode" : "STP1",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MVP1-FRSV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SV",
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MVP1-FRS54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "S",
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SS04-FRA01",
+  "setCode" : "SS04",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MAGO-FR002",
+  "setCode" : "MAGO",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SBCB-FR001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SBCB-FR001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GFTP-FR128",
+  "setCode" : "GFTP",
+  "printNumber" : 128,
   "rarity" : "ghost rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MGED-FR002",
+  "setCode" : "MGED",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "25TH-FR001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "HAC1-FR002",
+  "setCode" : "HAC1",
+  "printNumber" : 2,
   "rarity" : "duel terminal ultra parallel rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LC01-FR005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LC01-FR005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "quarter century secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LOB-FR005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SBC1-FRA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SBC1-FRA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TN23-FR001",
+  "setCode" : "TN23",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LDD-C005",
+  "setCode" : "LDD",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "DDY-C006",
+  "setCode" : "DDY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "DL1-C002",
+  "setCode" : "DL1",
+  "printNumber" : 2,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "MIY-I005",
+  "setCode" : "MIY",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "LDD-I003",
+  "setCode" : "LDD",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "PCY-I004",
+  "setCode" : "PCY",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "SYE-IT001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SD6-IT003",
+  "setCode" : "SD6",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RP01-IT003",
+  "setCode" : "RP01",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DPYG-IT001",
+  "setCode" : "DPYG",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LC01-IT005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DL11-IT001",
+  "setCode" : "DL11",
+  "printNumber" : 1,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCYW-IT001",
+  "setCode" : "LCYW",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSYR-IT001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSYR-IT001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "ultimate rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YGLD-ITA03",
+  "setCode" : "YGLD",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YGLD-ITC09",
+  "setCode" : "YGLD",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DPBC-IT008",
+  "setCode" : "DPBC",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MVP1-IT054",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "CT13-IT003",
+  "setCode" : "CT13",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LDK2-ITY10",
+  "setCode" : "LDK2",
+  "printNumber" : 10,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDMY-IT010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MVP1-ITGV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "GV",
   "rarity" : "gold secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MVP1-ITG54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "G",
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DUSA-IT100",
+  "setCode" : "DUSA",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "CT14-IT001",
+  "setCode" : "CT14",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LEDD-ITA01",
+  "setCode" : "LEDD",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YUCB-IT001",
+  "setCode" : "YUCB",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SS01-ITA01",
+  "setCode" : "SS01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DUPO-IT101",
+  "setCode" : "DUPO",
+  "printNumber" : 101,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "STP1-IT001",
+  "setCode" : "STP1",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MVP1-ITSV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SV",
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MVP1-ITS54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "S",
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SS04-ITA01",
+  "setCode" : "SS04",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MAGO-IT002",
+  "setCode" : "MAGO",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SBCB-IT001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SBCB-IT001",
+  "setCode" : "SBCB",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GFTP-IT128",
+  "setCode" : "GFTP",
+  "printNumber" : 128,
   "rarity" : "ghost rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MGED-IT002",
+  "setCode" : "MGED",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "25TH-IT001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "HAC1-IT002",
+  "setCode" : "HAC1",
+  "printNumber" : 2,
   "rarity" : "duel terminal ultra parallel rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LC01-IT005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LC01-IT005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "quarter century secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LOB-IT005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SBC1-ITA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SBC1-ITA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "secret",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TN23-IT001",
+  "setCode" : "TN23",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "setCode" : "Vol.1",
   "rarity" : "ultra rare",
@@ -1008,460 +1807,821 @@
   "language" : "ja"
 }, {
   "printCode" : "LB-05",
+  "setCode" : "LB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "EX-06",
+  "setCode" : "EX",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "YU-15",
+  "setCode" : "YU",
+  "printNumber" : 15,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "LN-53",
+  "setCode" : "LN",
+  "printNumber" : 53,
   "rarity" : "ultimate rare",
   "language" : "ja"
 }, {
   "printCode" : "DL2-005",
+  "setCode" : "DL2",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "DL2-005",
+  "setCode" : "DL2",
+  "printNumber" : 5,
   "rarity" : "ultra parallel rare",
   "language" : "ja"
 }, {
   "printCode" : "SY2-002",
+  "setCode" : "SY2",
+  "printNumber" : 2,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "BE1-JP102",
+  "setCode" : "BE1",
+  "printNumber" : 102,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD6-JP003",
+  "setCode" : "SD6",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DT01-JP002",
+  "setCode" : "DT01",
+  "printNumber" : 2,
   "rarity" : "duel terminal rare parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "WJMP-JP012",
+  "setCode" : "WJMP",
+  "printNumber" : 12,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BE01-JP092",
+  "setCode" : "BE01",
+  "printNumber" : 92,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "15AY-JPA03",
+  "setCode" : "15AY",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "15AY-JPC09",
+  "setCode" : "15AY",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "TRC1-JP001",
+  "setCode" : "TRC1",
+  "printNumber" : 1,
   "rarity" : "extra secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "15AX-JPY01",
+  "setCode" : "15AX",
+  "printNumber" : 1,
+  "printNumberPrefix" : "Y",
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "15AX-JPY01",
+  "setCode" : "15AX",
+  "printNumber" : 1,
+  "printNumberPrefix" : "Y",
   "rarity" : "millennium rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SJMP-JP002",
+  "setCode" : "SJMP",
+  "printNumber" : 2,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DP16-JP008",
+  "setCode" : "DP16",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MB01-JP010",
+  "setCode" : "MB01",
+  "printNumber" : 10,
   "rarity" : "millennium rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MVPI-JP001",
+  "setCode" : "MVPI",
+  "printNumber" : 1,
   "rarity" : "kaiba corporation common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SDMY-JP010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20AP-JP101",
+  "setCode" : "20AP",
+  "printNumber" : 101,
   "rarity" : "holographic parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LG01-JP001",
+  "setCode" : "LG01",
+  "printNumber" : 1,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "2018-JPP02",
+  "setCode" : "2018",
+  "printNumber" : 2,
+  "printNumberPrefix" : "P",
   "rarity" : "20th secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "YCPC-JP004",
+  "setCode" : "YCPC",
+  "printNumber" : 4,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "YCPC-JP004",
+  "setCode" : "YCPC",
+  "printNumber" : 4,
   "rarity" : "millennium rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "setCode" : "20th Anniversary Duelist Box",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "20TH-JPBS1",
+  "setCode" : "20TH",
+  "printNumber" : 1,
+  "printNumberPrefix" : "BS",
   "rarity" : "20th secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPC57",
+  "setCode" : "20TH",
+  "printNumber" : 57,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPC57",
+  "setCode" : "20TH",
+  "printNumber" : 57,
+  "printNumberPrefix" : "C",
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20CP-JPS01",
+  "setCode" : "20CP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "S",
   "rarity" : "20th secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LGB1-JPS01",
+  "setCode" : "LGB1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "S",
   "rarity" : "premium gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PSEC-JP002",
+  "setCode" : "PSEC",
+  "printNumber" : 2,
   "rarity" : "prismatic secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PGB1-JP011",
+  "setCode" : "PGB1",
+  "printNumber" : 11,
   "rarity" : "millennium ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PGB1-JP011",
+  "setCode" : "PGB1",
+  "printNumber" : 11,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP004",
+  "setCode" : "PAC1",
+  "printNumber" : 4,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP004",
+  "setCode" : "PAC1",
+  "printNumber" : 4,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP004",
+  "setCode" : "PAC1",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DR01-JPA01",
+  "setCode" : "DR01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DR01-JPA01",
+  "setCode" : "DR01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PPC1-JP001",
+  "setCode" : "PPC1",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PPC1-JP001",
+  "setCode" : "PPC1",
+  "printNumber" : 1,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "25TH-JP001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "setCode" : "\"Dark Magician\" Special Card",
   "rarity" : "ultra rare",
   "language" : "ja"
 }, {
   "printCode" : "CCC1-JP001",
+  "setCode" : "CCC1",
+  "printNumber" : 1,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "711C-JP001",
+  "setCode" : "711C",
+  "printNumber" : 1,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LOB-K005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "SDY-K006",
+  "setCode" : "SDY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "BP1-KR102",
+  "setCode" : "BP1",
+  "printNumber" : 102,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SYE-KR001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD6-KR003",
+  "setCode" : "SD6",
+  "printNumber" : 3,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PP01-KR017",
+  "setCode" : "PP01",
+  "printNumber" : 17,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DP00-KR001",
+  "setCode" : "DP00",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "MOV-KR005",
+  "setCode" : "MOV",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "MB01-KR010",
+  "setCode" : "MB01",
+  "printNumber" : 10,
   "rarity" : "millennium rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "MVPC-KR005",
+  "setCode" : "MVPC",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DP16-KR008",
+  "setCode" : "DP16",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SDMY-KR010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "20AP-KR101",
+  "setCode" : "20AP",
+  "printNumber" : 101,
   "rarity" : "extra secret parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AY-KRA03",
+  "setCode" : "15AY",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "TRC1-KR001",
+  "setCode" : "TRC1",
+  "printNumber" : 1,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AY-KRC09",
+  "setCode" : "15AY",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AY-KRA03",
+  "setCode" : "15AY",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "CHBI-KRBS1",
+  "setCode" : "CHBI",
+  "printNumber" : 1,
+  "printNumberPrefix" : "BS",
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LEC1-KR057",
+  "setCode" : "LEC1",
+  "printNumber" : 57,
   "rarity" : "ultra parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LEC1-KR057",
+  "setCode" : "LEC1",
+  "printNumber" : 57,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AX-KRY01",
+  "setCode" : "15AX",
+  "printNumber" : 1,
+  "printNumberPrefix" : "Y",
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "15AX-KRY01",
+  "setCode" : "15AX",
+  "printNumber" : 1,
+  "printNumberPrefix" : "Y",
   "rarity" : "millennium rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LGB1-KRS01",
+  "setCode" : "LGB1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "S",
   "rarity" : "premium gold rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LGB1-KRGE1",
+  "setCode" : "LGB1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "GE",
   "rarity" : "premium gold rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR004",
+  "setCode" : "PAC1",
+  "printNumber" : 4,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR004",
+  "setCode" : "PAC1",
+  "printNumber" : 4,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR004",
+  "setCode" : "PAC1",
+  "printNumber" : 4,
   "rarity" : "prismatic secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "25TH-KR001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GPC1-KR001",
+  "setCode" : "GPC1",
+  "printNumber" : 1,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DIY-P006",
+  "setCode" : "DIY",
+  "printNumber" : 6,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "LDB-P005",
+  "setCode" : "LDB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "SYE-PT001",
+  "setCode" : "SYE",
+  "printNumber" : 1,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YSYR-PT001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YSYR-PT001",
+  "setCode" : "YSYR",
+  "printNumber" : 1,
   "rarity" : "ultimate rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YGLD-PTA03",
+  "setCode" : "YGLD",
+  "printNumber" : 3,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YGLD-PTC09",
+  "setCode" : "YGLD",
+  "printNumber" : 9,
+  "printNumberPrefix" : "C",
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DPBC-PT008",
+  "setCode" : "DPBC",
+  "printNumber" : 8,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MVP1-PT054",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "CT13-PT003",
+  "setCode" : "CT13",
+  "printNumber" : 3,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LDK2-PTY10",
+  "setCode" : "LDK2",
+  "printNumber" : 10,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SDMY-PT010",
+  "setCode" : "SDMY",
+  "printNumber" : 10,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MVP1-PTGV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "GV",
   "rarity" : "gold secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MVP1-PTG54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "G",
   "rarity" : "gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DUSA-PT100",
+  "setCode" : "DUSA",
+  "printNumber" : 100,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "CT14-PT001",
+  "setCode" : "CT14",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LEDD-PTA01",
+  "setCode" : "LEDD",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SS01-PTA01",
+  "setCode" : "SS01",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DUPO-PT101",
+  "setCode" : "DUPO",
+  "printNumber" : 101,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "STP1-PT001",
+  "setCode" : "STP1",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MVP1-PTSV3",
+  "setCode" : "MVP1",
+  "printNumber" : 3,
+  "printNumberPrefix" : "SV",
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MVP1-PTS54",
+  "setCode" : "MVP1",
+  "printNumber" : 54,
+  "printNumberPrefix" : "S",
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SS04-PTA01",
+  "setCode" : "SS04",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MAGO-PT002",
+  "setCode" : "MAGO",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "GFTP-PT128",
+  "setCode" : "GFTP",
+  "printNumber" : 128,
   "rarity" : "ghost rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MGED-PT002",
+  "setCode" : "MGED",
+  "printNumber" : 2,
   "rarity" : "premium gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "25TH-PT001",
+  "setCode" : "25TH",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "HAC1-PT002",
+  "setCode" : "HAC1",
+  "printNumber" : 2,
   "rarity" : "duel terminal ultra parallel rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LC01-PT005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LC01-PT005",
+  "setCode" : "LC01",
+  "printNumber" : 5,
   "rarity" : "quarter century secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LOB-PT005",
+  "setCode" : "LOB",
+  "printNumber" : 5,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SBC1-PTA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SBC1-PTA01",
+  "setCode" : "SBC1",
+  "printNumber" : 1,
+  "printNumberPrefix" : "A",
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "TN23-PT001",
+  "setCode" : "TN23",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "TRC1-SC001",
+  "setCode" : "TRC1",
+  "printNumber" : 1,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "CL01-SC001",
+  "setCode" : "CL01",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "CL01-SC001",
+  "setCode" : "CL01",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "PSEC-SC002",
+  "setCode" : "PSEC",
+  "printNumber" : 2,
   "rarity" : "prismatic secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "setCode" : "\"Dark Magician\" Giveaway for 1000 People!",
   "rarity" : "ultra rare",

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/pendulum_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/pendulum_monster.approved.json
@@ -1,33 +1,57 @@
 [ {
   "printCode" : "SR08-EN001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SR08-DE001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SR08-SP001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SR08-FR001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SR08-IT001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SR08-JP001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SR08-KR001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SR08-PT001",
+  "setCode" : "SR08",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/pendulum_non_effect_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/pendulum_non_effect_monster.approved.json
@@ -1,97 +1,169 @@
 [ {
   "printCode" : "NECH-EN021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MP15-EN144",
+  "setCode" : "MP15",
+  "printNumber" : 144,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "PEVO-EN057",
+  "setCode" : "PEVO",
+  "printNumber" : 57,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "NECH-DE021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MP15-DE144",
+  "setCode" : "MP15",
+  "printNumber" : 144,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "PEVO-DE057",
+  "setCode" : "PEVO",
+  "printNumber" : 57,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "NECH-SP021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MP15-SP144",
+  "setCode" : "MP15",
+  "printNumber" : 144,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "PEVO-SP057",
+  "setCode" : "PEVO",
+  "printNumber" : 57,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "NECH-FR021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MP15-FR144",
+  "setCode" : "MP15",
+  "printNumber" : 144,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "PEVO-FR057",
+  "setCode" : "PEVO",
+  "printNumber" : 57,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "NECH-IT021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MP15-IT144",
+  "setCode" : "MP15",
+  "printNumber" : 144,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "PEVO-IT057",
+  "setCode" : "PEVO",
+  "printNumber" : 57,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "NECH-JP021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20AP-JP098",
+  "setCode" : "20AP",
+  "printNumber" : 98,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LVP1-JP062",
+  "setCode" : "LVP1",
+  "printNumber" : 62,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "NECH-KR021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "20AP-KR098",
+  "setCode" : "20AP",
+  "printNumber" : 98,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LVP1-KR062",
+  "setCode" : "LVP1",
+  "printNumber" : 62,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "NECH-PT021",
+  "setCode" : "NECH",
+  "printNumber" : 21,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MP15-PT144",
+  "setCode" : "MP15",
+  "printNumber" : 144,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "PEVO-PT057",
+  "setCode" : "PEVO",
+  "printNumber" : 57,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/spell.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/spell.approved.json
@@ -1,691 +1,1220 @@
 [ {
   "printCode" : "SYE-026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "DB1-EN113",
+  "setCode" : "DB1",
+  "printNumber" : 113,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TU04-EN017",
+  "setCode" : "TU04",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TU05-EN001",
+  "setCode" : "TU05",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GLD5-EN037",
+  "setCode" : "GLD5",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDWA-EN023",
+  "setCode" : "SDWA",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCYW-EN053",
+  "setCode" : "LCYW",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDRE-EN031",
+  "setCode" : "SDRE",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCJW-EN283",
+  "setCode" : "LCJW",
+  "printNumber" : 283,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSKR-EN028",
+  "setCode" : "YSKR",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSYR-EN025",
+  "setCode" : "YSYR",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS14-ENA10",
+  "setCode" : "YS14",
+  "printNumber" : 10,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "NKRT-EN024",
+  "setCode" : "NKRT",
+  "printNumber" : 24,
   "rarity" : "platinum rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "PGL2-EN089",
+  "setCode" : "PGL2",
+  "printNumber" : 89,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DESO-EN042",
+  "setCode" : "DESO",
+  "printNumber" : 42,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS17-EN023",
+  "setCode" : "YS17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS18-EN025",
+  "setCode" : "YS18",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LEHD-ENB21",
+  "setCode" : "LEHD",
+  "printNumber" : 21,
+  "printNumberPrefix" : "B",
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LEHD-ENC15",
+  "setCode" : "LEHD",
+  "printNumber" : 15,
+  "printNumberPrefix" : "C",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "OP12-EN022",
+  "setCode" : "OP12",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BLMR-EN086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "BLMR-EN086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "OP23-EN023",
+  "setCode" : "OP23",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SR14-EN030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
   "language" : "en"
 }, {
   "printCode" : "SDY-022",
+  "setCode" : "SDY",
+  "printNumber" : 22,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDK-022",
+  "setCode" : "SDK",
+  "printNumber" : 22,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDJ-026",
+  "setCode" : "SDJ",
+  "printNumber" : 26,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDP-026",
+  "setCode" : "SDP",
+  "printNumber" : 26,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "YS15-ENF13",
+  "setCode" : "YS15",
+  "printNumber" : 13,
+  "printNumberPrefix" : "F",
   "rarity" : "shatterfoil rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS15-ENL14",
+  "setCode" : "YS15",
+  "printNumber" : 14,
+  "printNumberPrefix" : "L",
   "rarity" : "shatterfoil rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-E041",
+  "setCode" : "LOB",
+  "printNumber" : 41,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "SDY-E020",
+  "setCode" : "SDY",
+  "printNumber" : 20,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "SDK-E021",
+  "setCode" : "SDK",
+  "printNumber" : 21,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "YS15-ENY12",
+  "setCode" : "YS15",
+  "printNumber" : 12,
+  "printNumberPrefix" : "Y",
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DEM3-EN012",
+  "setCode" : "DEM3",
+  "printNumber" : 12,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-A052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "SDY-A022",
+  "setCode" : "SDY",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "SDK-A022",
+  "setCode" : "SDK",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "LOB-052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
   "language" : "en"
 }, {
   "printCode" : "SDY-022",
+  "setCode" : "SDY",
+  "printNumber" : 22,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDK-022",
+  "setCode" : "SDK",
+  "printNumber" : 22,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "LOB-G041",
+  "setCode" : "LOB",
+  "printNumber" : 41,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDY-G020",
+  "setCode" : "SDY",
+  "printNumber" : 20,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDK-G021",
+  "setCode" : "SDK",
+  "printNumber" : 21,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDJ-G026",
+  "setCode" : "SDJ",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDP-G026",
+  "setCode" : "SDP",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "DB1-DE113",
+  "setCode" : "DB1",
+  "printNumber" : 113,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SYE-DE026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TU04-DE017",
+  "setCode" : "TU04",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TU05-DE001",
+  "setCode" : "TU05",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GLD5-DE037",
+  "setCode" : "GLD5",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDWA-DE023",
+  "setCode" : "SDWA",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCYW-DE053",
+  "setCode" : "LCYW",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDRE-DE031",
+  "setCode" : "SDRE",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCJW-DE283",
+  "setCode" : "LCJW",
+  "printNumber" : 283,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSKR-DE028",
+  "setCode" : "YSKR",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSYR-DE025",
+  "setCode" : "YSYR",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS14-DEA10",
+  "setCode" : "YS14",
+  "printNumber" : 10,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "NKRT-DE024",
+  "setCode" : "NKRT",
+  "printNumber" : 24,
   "rarity" : "platinum rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "PGL2-DE089",
+  "setCode" : "PGL2",
+  "printNumber" : 89,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS15-DEY12",
+  "setCode" : "YS15",
+  "printNumber" : 12,
+  "printNumberPrefix" : "Y",
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DEM3-DE012",
+  "setCode" : "DEM3",
+  "printNumber" : 12,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DESO-DE042",
+  "setCode" : "DESO",
+  "printNumber" : 42,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS17-DE023",
+  "setCode" : "YS17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS18-DE025",
+  "setCode" : "YS18",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LEHD-DEB21",
+  "setCode" : "LEHD",
+  "printNumber" : 21,
+  "printNumberPrefix" : "B",
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LEHD-DEC15",
+  "setCode" : "LEHD",
+  "printNumber" : 15,
+  "printNumberPrefix" : "C",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "OP12-DE022",
+  "setCode" : "OP12",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LOB-DE052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BLMR-DE086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "BLMR-DE086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "quarter century secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "OP23-DE023",
+  "setCode" : "OP23",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SR14-DE030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LDD-S052",
+  "setCode" : "LDD",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIY-S022",
+  "setCode" : "BIY",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIK-S022",
+  "setCode" : "BIK",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIJ-S026",
+  "setCode" : "BIJ",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIP-S026",
+  "setCode" : "BIP",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "DB1-SP113",
+  "setCode" : "DB1",
+  "printNumber" : 113,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SYE-SP026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TU04-SP017",
+  "setCode" : "TU04",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TU05-SP001",
+  "setCode" : "TU05",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GLD5-SP037",
+  "setCode" : "GLD5",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDWA-SP023",
+  "setCode" : "SDWA",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCYW-SP053",
+  "setCode" : "LCYW",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDRE-SP031",
+  "setCode" : "SDRE",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCJW-SP283",
+  "setCode" : "LCJW",
+  "printNumber" : 283,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSKR-SP028",
+  "setCode" : "YSKR",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSYR-SP025",
+  "setCode" : "YSYR",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS14-SPA10",
+  "setCode" : "YS14",
+  "printNumber" : 10,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "NKRT-SP024",
+  "setCode" : "NKRT",
+  "printNumber" : 24,
   "rarity" : "platinum rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "PGL2-SP089",
+  "setCode" : "PGL2",
+  "printNumber" : 89,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS15-SPY12",
+  "setCode" : "YS15",
+  "printNumber" : 12,
+  "printNumberPrefix" : "Y",
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DESO-SP042",
+  "setCode" : "DESO",
+  "printNumber" : 42,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS17-SP023",
+  "setCode" : "YS17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS18-SP025",
+  "setCode" : "YS18",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LEHD-SPB21",
+  "setCode" : "LEHD",
+  "printNumber" : 21,
+  "printNumberPrefix" : "B",
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LEHD-SPC15",
+  "setCode" : "LEHD",
+  "printNumber" : 15,
+  "printNumberPrefix" : "C",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "OP12-SP022",
+  "setCode" : "OP12",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LOB-SP052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BLMR-SP086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "BLMR-SP086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "quarter century secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "OP23-SP023",
+  "setCode" : "OP23",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SR14-SP030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LDD-F041",
+  "setCode" : "LDD",
+  "printNumber" : 41,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDY-F020",
+  "setCode" : "DDY",
+  "printNumber" : 20,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDK-F021",
+  "setCode" : "DDK",
+  "printNumber" : 21,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDJ-F026",
+  "setCode" : "DDJ",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDP-F026",
+  "setCode" : "DDP",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "SYE-FR026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TU04-FR017",
+  "setCode" : "TU04",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TU05-FR001",
+  "setCode" : "TU05",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GLD5-FR037",
+  "setCode" : "GLD5",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDWA-FR023",
+  "setCode" : "SDWA",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCYW-FR053",
+  "setCode" : "LCYW",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDRE-FR031",
+  "setCode" : "SDRE",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCJW-FR283",
+  "setCode" : "LCJW",
+  "printNumber" : 283,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSKR-FR028",
+  "setCode" : "YSKR",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSYR-FR025",
+  "setCode" : "YSYR",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS14-FRA10",
+  "setCode" : "YS14",
+  "printNumber" : 10,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "NKRT-FR024",
+  "setCode" : "NKRT",
+  "printNumber" : 24,
   "rarity" : "platinum rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "PGL2-FR089",
+  "setCode" : "PGL2",
+  "printNumber" : 89,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS15-FRY12",
+  "setCode" : "YS15",
+  "printNumber" : 12,
+  "printNumberPrefix" : "Y",
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DEM3-FR012",
+  "setCode" : "DEM3",
+  "printNumber" : 12,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DESO-FR042",
+  "setCode" : "DESO",
+  "printNumber" : 42,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS17-FR023",
+  "setCode" : "YS17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS18-FR025",
+  "setCode" : "YS18",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LEHD-FRB21",
+  "setCode" : "LEHD",
+  "printNumber" : 21,
+  "printNumberPrefix" : "B",
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LEHD-FRC15",
+  "setCode" : "LEHD",
+  "printNumber" : 15,
+  "printNumberPrefix" : "C",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "OP12-FR022",
+  "setCode" : "OP12",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LOB-FR052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BLMR-FR086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "BLMR-FR086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "quarter century secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "OP23-FR023",
+  "setCode" : "OP23",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SR14-FR030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LDD-C052",
+  "setCode" : "LDD",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "DDY-C022",
+  "setCode" : "DDY",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "DDK-C022",
+  "setCode" : "DDK",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "LDD-I041",
+  "setCode" : "LDD",
+  "printNumber" : 41,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIY-I020",
+  "setCode" : "MIY",
+  "printNumber" : 20,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIK-I021",
+  "setCode" : "MIK",
+  "printNumber" : 21,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIJ-I026",
+  "setCode" : "MIJ",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIP-I026",
+  "setCode" : "MIP",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "SYE-IT026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TU04-IT017",
+  "setCode" : "TU04",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TU05-IT001",
+  "setCode" : "TU05",
+  "printNumber" : 1,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GLD5-IT037",
+  "setCode" : "GLD5",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDWA-IT023",
+  "setCode" : "SDWA",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCYW-IT053",
+  "setCode" : "LCYW",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDRE-IT031",
+  "setCode" : "SDRE",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCJW-IT283",
+  "setCode" : "LCJW",
+  "printNumber" : 283,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSKR-IT028",
+  "setCode" : "YSKR",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSYR-IT025",
+  "setCode" : "YSYR",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS14-ITA10",
+  "setCode" : "YS14",
+  "printNumber" : 10,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "NKRT-IT024",
+  "setCode" : "NKRT",
+  "printNumber" : 24,
   "rarity" : "platinum rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "PGL2-IT089",
+  "setCode" : "PGL2",
+  "printNumber" : 89,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS15-ITY12",
+  "setCode" : "YS15",
+  "printNumber" : 12,
+  "printNumberPrefix" : "Y",
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DEM3-IT012",
+  "setCode" : "DEM3",
+  "printNumber" : 12,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DESO-IT042",
+  "setCode" : "DESO",
+  "printNumber" : 42,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS17-IT023",
+  "setCode" : "YS17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS18-IT025",
+  "setCode" : "YS18",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LEHD-ITB21",
+  "setCode" : "LEHD",
+  "printNumber" : 21,
+  "printNumberPrefix" : "B",
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LEHD-ITC15",
+  "setCode" : "LEHD",
+  "printNumber" : 15,
+  "printNumberPrefix" : "C",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "OP12-IT022",
+  "setCode" : "OP12",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LOB-IT052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BLMR-IT086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "BLMR-IT086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "quarter century secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "OP23-IT023",
+  "setCode" : "OP23",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SR14-IT030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "setCode" : "Vol.1",
   "rarity" : "super rare",
@@ -696,298 +1225,527 @@
   "language" : "ja"
 }, {
   "printCode" : "LB-51",
+  "setCode" : "LB",
+  "printNumber" : 51,
   "rarity" : "super rare",
   "language" : "ja"
 }, {
   "printCode" : "EX-22",
+  "setCode" : "EX",
+  "printNumber" : 22,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "YU-28",
+  "setCode" : "YU",
+  "printNumber" : 28,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "JY-27",
+  "setCode" : "JY",
+  "printNumber" : 27,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "KA-29",
+  "setCode" : "KA",
+  "printNumber" : 29,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "DL2-033",
+  "setCode" : "DL2",
+  "printNumber" : 33,
   "rarity" : "super rare",
   "language" : "ja"
 }, {
   "printCode" : "BE1-JP113",
+  "setCode" : "BE1",
+  "printNumber" : 113,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS03-JP012",
+  "setCode" : "GS03",
+  "printNumber" : 12,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS03-JP012",
+  "setCode" : "GS03",
+  "printNumber" : 12,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BE01-JP098",
+  "setCode" : "BE01",
+  "printNumber" : 98,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD23-JP030",
+  "setCode" : "SD23",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GDB1-JP052",
+  "setCode" : "GDB1",
+  "printNumber" : 52,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "ST12-JPP02",
+  "setCode" : "ST12",
+  "printNumber" : 2,
+  "printNumberPrefix" : "P",
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DS13-JPD30",
+  "setCode" : "DS13",
+  "printNumber" : 30,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "ST14-JPA06",
+  "setCode" : "ST14",
+  "printNumber" : 6,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "VS15-JPS14",
+  "setCode" : "VS15",
+  "printNumber" : 14,
+  "printNumberPrefix" : "S",
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "VS15-JPD15",
+  "setCode" : "VS15",
+  "printNumber" : 15,
+  "printNumberPrefix" : "D",
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SPDS-JP042",
+  "setCode" : "SPDS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SPDS-JP042",
+  "setCode" : "SPDS",
+  "printNumber" : 42,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "ST17-JP023",
+  "setCode" : "ST17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "ST18-JP024",
+  "setCode" : "ST18",
+  "printNumber" : 24,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "WP01-JP003",
+  "setCode" : "WP01",
+  "printNumber" : 3,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SR14-JP030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LOB-K052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "SDY-K022",
+  "setCode" : "SDY",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "SDK-K022",
+  "setCode" : "SDK",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "BP1-KR113",
+  "setCode" : "BP1",
+  "printNumber" : 113,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SDJ-KR026",
+  "setCode" : "SDJ",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SDP-KR026",
+  "setCode" : "SDP",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SYE-KR026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS03-KR012",
+  "setCode" : "GS03",
+  "printNumber" : 12,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS03-KR012",
+  "setCode" : "GS03",
+  "printNumber" : 12,
   "rarity" : "gold rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD23-KR030",
+  "setCode" : "SD23",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DS13-KRD30",
+  "setCode" : "DS13",
+  "printNumber" : 30,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "AE03-KR001",
+  "setCode" : "AE03",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "ST14-KRA06",
+  "setCode" : "ST14",
+  "printNumber" : 6,
+  "printNumberPrefix" : "A",
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "VS15-KRS14",
+  "setCode" : "VS15",
+  "printNumber" : 14,
+  "printNumberPrefix" : "S",
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "VS15-KRD15",
+  "setCode" : "VS15",
+  "printNumber" : 15,
+  "printNumberPrefix" : "D",
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SPDS-KR042",
+  "setCode" : "SPDS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SPDS-KR042",
+  "setCode" : "SPDS",
+  "printNumber" : 42,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "ST17-KR023",
+  "setCode" : "ST17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "ST18-KR024",
+  "setCode" : "ST18",
+  "printNumber" : 24,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LDB-P052",
+  "setCode" : "LDB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIY-P022",
+  "setCode" : "DIY",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIK-P022",
+  "setCode" : "DIK",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIJ-P026",
+  "setCode" : "DIJ",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIP-P026",
+  "setCode" : "DIP",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "SYE-PT026",
+  "setCode" : "SYE",
+  "printNumber" : 26,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LCJW-PT283",
+  "setCode" : "LCJW",
+  "printNumber" : 283,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YSKR-PT028",
+  "setCode" : "YSKR",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YSYR-PT025",
+  "setCode" : "YSYR",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YS14-PTA10",
+  "setCode" : "YS14",
+  "printNumber" : 10,
+  "printNumberPrefix" : "A",
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "NKRT-PT024",
+  "setCode" : "NKRT",
+  "printNumber" : 24,
   "rarity" : "platinum rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "PGL2-PT089",
+  "setCode" : "PGL2",
+  "printNumber" : 89,
   "rarity" : "gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YS15-PTY12",
+  "setCode" : "YS15",
+  "printNumber" : 12,
+  "printNumberPrefix" : "Y",
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DESO-PT042",
+  "setCode" : "DESO",
+  "printNumber" : 42,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YS17-PT023",
+  "setCode" : "YS17",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YS18-PT025",
+  "setCode" : "YS18",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LEHD-PTB21",
+  "setCode" : "LEHD",
+  "printNumber" : 21,
+  "printNumberPrefix" : "B",
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LEHD-PTC15",
+  "setCode" : "LEHD",
+  "printNumber" : 15,
+  "printNumberPrefix" : "C",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "OP12-PT022",
+  "setCode" : "OP12",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LOB-PT052",
+  "setCode" : "LOB",
+  "printNumber" : 52,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "BLMR-PT086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "BLMR-PT086",
+  "setCode" : "BLMR",
+  "printNumber" : 86,
   "rarity" : "quarter century secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "OP23-PT023",
+  "setCode" : "OP23",
+  "printNumber" : 23,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SR14-PT030",
+  "setCode" : "SR14",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "ST20-SC022",
+  "setCode" : "ST20",
+  "printNumber" : 22,
   "rarity" : "common",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC048",
+  "setCode" : "23RC",
+  "printNumber" : 48,
   "rarity" : "super rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC048",
+  "setCode" : "23RC",
+  "printNumber" : 48,
   "rarity" : "ultimate rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC048",
+  "setCode" : "23RC",
+  "printNumber" : 48,
   "rarity" : "collector's rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC048",
+  "setCode" : "23RC",
+  "printNumber" : 48,
   "rarity" : "secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC048",
+  "setCode" : "23RC",
+  "printNumber" : 48,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "23RC-SC048",
+  "setCode" : "23RC",
+  "printNumber" : 48,
   "rarity" : "quarter century secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "SP02-TC037",
+  "setCode" : "SP02",
+  "printNumber" : 37,
   "rarity" : "ultra rare",
-  "language" : "zh-Hant"
+  "language" : "zh-Hant",
+  "regionCode" : "TC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/synchro_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/synchro_monster.approved.json
@@ -1,553 +1,980 @@
 [ {
   "printCode" : "CT05-EN001",
+  "setCode" : "CT05",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TDGS-EN040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TDGS-EN040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TDGS-EN040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ghost rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DP08-EN014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GLD3-EN037",
+  "setCode" : "GLD3",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "CT07-EN021",
+  "setCode" : "CT07",
+  "printNumber" : 21,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TU06-EN007",
+  "setCode" : "TU06",
+  "printNumber" : 7,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SHSP-ENSE1",
+  "setCode" : "SHSP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "PGLD-EN076",
+  "setCode" : "PGLD",
+  "printNumber" : 76,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LC5D-EN031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LC5D-EN031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DUPO-EN103",
+  "setCode" : "DUPO",
+  "printNumber" : 103,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TOCH-EN050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TOCH-EN050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DAMA-EN100",
+  "setCode" : "DAMA",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "TN23-EN016",
+  "setCode" : "TN23",
+  "printNumber" : 16,
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "CR01-AE012",
+  "setCode" : "CR01",
+  "printNumber" : 12,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "CR01-AE012",
+  "setCode" : "CR01",
+  "printNumber" : 12,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "CR01-AES03",
+  "setCode" : "CR01",
+  "printNumber" : 3,
+  "printNumberPrefix" : "S",
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "CR01-AES03",
+  "setCode" : "CR01",
+  "printNumber" : 3,
+  "printNumberPrefix" : "S",
   "rarity" : "quarter century secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "CT05-DE001",
+  "setCode" : "CT05",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TDGS-DE040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TDGS-DE040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TDGS-DE040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ghost rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DP08-DE014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GLD3-DE037",
+  "setCode" : "GLD3",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "CT07-DE021",
+  "setCode" : "CT07",
+  "printNumber" : 21,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TU06-DE007",
+  "setCode" : "TU06",
+  "printNumber" : 7,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "AC11-DE024",
+  "setCode" : "AC11",
+  "printNumber" : 24,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SHSP-DESE1",
+  "setCode" : "SHSP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "PGLD-DE076",
+  "setCode" : "PGLD",
+  "printNumber" : 76,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LC5D-DE031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LC5D-DE031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DUPO-DE103",
+  "setCode" : "DUPO",
+  "printNumber" : 103,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TOCH-DE050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TOCH-DE050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DAMA-DE100",
+  "setCode" : "DAMA",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "TN23-DE016",
+  "setCode" : "TN23",
+  "printNumber" : 16,
   "rarity" : "quarter century secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "CT05-SP001",
+  "setCode" : "CT05",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TDGS-SP040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TDGS-SP040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TDGS-SP040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ghost rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DP08-SP014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GLD3-SP037",
+  "setCode" : "GLD3",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "CT07-SP021",
+  "setCode" : "CT07",
+  "printNumber" : 21,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TU06-SP007",
+  "setCode" : "TU06",
+  "printNumber" : 7,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SHSP-SPSE1",
+  "setCode" : "SHSP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "PGLD-SP076",
+  "setCode" : "PGLD",
+  "printNumber" : 76,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LC5D-SP031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LC5D-SP031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DUPO-SP103",
+  "setCode" : "DUPO",
+  "printNumber" : 103,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TOCH-SP050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TOCH-SP050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DAMA-SP100",
+  "setCode" : "DAMA",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "TN23-SP016",
+  "setCode" : "TN23",
+  "printNumber" : 16,
   "rarity" : "quarter century secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "CT05-FR001",
+  "setCode" : "CT05",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TDGS-FR040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TDGS-FR040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TDGS-FR040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ghost rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DP08-FR014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GLD3-FR037",
+  "setCode" : "GLD3",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "CT07-FR021",
+  "setCode" : "CT07",
+  "printNumber" : 21,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TU06-FR007",
+  "setCode" : "TU06",
+  "printNumber" : 7,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SHSP-FRSE1",
+  "setCode" : "SHSP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "PGLD-FR076",
+  "setCode" : "PGLD",
+  "printNumber" : 76,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LC5D-FR031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LC5D-FR031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DUPO-FR103",
+  "setCode" : "DUPO",
+  "printNumber" : 103,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TOCH-FR050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TOCH-FR050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DAMA-FR100",
+  "setCode" : "DAMA",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "TN23-FR016",
+  "setCode" : "TN23",
+  "printNumber" : 16,
   "rarity" : "quarter century secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "CT05-IT001",
+  "setCode" : "CT05",
+  "printNumber" : 1,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TDGS-IT040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TDGS-IT040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TDGS-IT040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ghost rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DP08-IT014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GLD3-IT037",
+  "setCode" : "GLD3",
+  "printNumber" : 37,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "CT07-IT021",
+  "setCode" : "CT07",
+  "printNumber" : 21,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TU06-IT007",
+  "setCode" : "TU06",
+  "printNumber" : 7,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SHSP-ITSE1",
+  "setCode" : "SHSP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "PGLD-IT076",
+  "setCode" : "PGLD",
+  "printNumber" : 76,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LC5D-IT031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LC5D-IT031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DUPO-IT103",
+  "setCode" : "DUPO",
+  "printNumber" : 103,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TOCH-IT050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TOCH-IT050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DAMA-IT100",
+  "setCode" : "DAMA",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TN23-IT016",
+  "setCode" : "TN23",
+  "printNumber" : 16,
   "rarity" : "quarter century secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "TDGS-JP040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "TDGS-JP040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "TDGS-JP040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "holographic rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DP08-JP014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "MFC1-JP001",
+  "setCode" : "MFC1",
+  "printNumber" : 1,
   "rarity" : "duel terminal normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS04-JP009",
+  "setCode" : "GS04",
+  "printNumber" : 9,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS04-JP009",
+  "setCode" : "GS04",
+  "printNumber" : 9,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DE03-JP015",
+  "setCode" : "DE03",
+  "printNumber" : 15,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GDB1-JP069",
+  "setCode" : "GDB1",
+  "printNumber" : 69,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "TRC1-JP005",
+  "setCode" : "TRC1",
+  "printNumber" : 5,
   "rarity" : "extra secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GP16-JP009",
+  "setCode" : "GP16",
+  "printNumber" : 9,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GP16-JP009",
+  "setCode" : "GP16",
+  "printNumber" : 9,
   "rarity" : "gold secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20TH-JPBS3",
+  "setCode" : "20TH",
+  "printNumber" : 3,
+  "printNumberPrefix" : "BS",
   "rarity" : "20th secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20CP-JPT06",
+  "setCode" : "20CP",
+  "printNumber" : 6,
+  "printNumberPrefix" : "T",
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "20CP-JPT06",
+  "setCode" : "20CP",
+  "printNumber" : 6,
+  "printNumberPrefix" : "T",
   "rarity" : "20th secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP006",
+  "setCode" : "PAC1",
+  "printNumber" : 6,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP006",
+  "setCode" : "PAC1",
+  "printNumber" : 6,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "PAC1-JP006",
+  "setCode" : "PAC1",
+  "printNumber" : 6,
   "rarity" : "prismatic secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "CCC1-JP003",
+  "setCode" : "CCC1",
+  "printNumber" : 3,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "TDGS-KR040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "TDGS-KR040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "TDGS-KR040",
+  "setCode" : "TDGS",
+  "printNumber" : 40,
   "rarity" : "holographic rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DP08-KR014",
+  "setCode" : "DP08",
+  "printNumber" : 14,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DP00-KRSE1",
+  "setCode" : "DP00",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS04-KR009",
+  "setCode" : "GS04",
+  "printNumber" : 9,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS04-KR009",
+  "setCode" : "GS04",
+  "printNumber" : 9,
   "rarity" : "gold rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "TRC1-KR005",
+  "setCode" : "TRC1",
+  "printNumber" : 5,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "CHBI-KRBS3",
+  "setCode" : "CHBI",
+  "printNumber" : 3,
+  "printNumberPrefix" : "BS",
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SP19-KR026",
+  "setCode" : "SP19",
+  "printNumber" : 26,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SP19-KR026",
+  "setCode" : "SP19",
+  "printNumber" : 26,
   "rarity" : "extra secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR006",
+  "setCode" : "PAC1",
+  "printNumber" : 6,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR006",
+  "setCode" : "PAC1",
+  "printNumber" : 6,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PAC1-KR006",
+  "setCode" : "PAC1",
+  "printNumber" : 6,
   "rarity" : "prismatic secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SYP1-KR106",
+  "setCode" : "SYP1",
+  "printNumber" : 106,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SYP1-KR106",
+  "setCode" : "SYP1",
+  "printNumber" : 106,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SYP1-KR106",
+  "setCode" : "SYP1",
+  "printNumber" : 106,
   "rarity" : "quarter century secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GPC1-KR004",
+  "setCode" : "GPC1",
+  "printNumber" : 4,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SHSP-PTSE1",
+  "setCode" : "SHSP",
+  "printNumber" : 1,
+  "printNumberPrefix" : "SE",
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "PGLD-PT076",
+  "setCode" : "PGLD",
+  "printNumber" : 76,
   "rarity" : "gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LC5D-PT031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LC5D-PT031",
+  "setCode" : "LC5D",
+  "printNumber" : 31,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DUPO-PT103",
+  "setCode" : "DUPO",
+  "printNumber" : 103,
   "rarity" : "ultra rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "TOCH-PT050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "TOCH-PT050",
+  "setCode" : "TOCH",
+  "printNumber" : 50,
   "rarity" : "collector's rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "DAMA-PT100",
+  "setCode" : "DAMA",
+  "printNumber" : 100,
   "rarity" : "starlight rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "TN23-PT016",
+  "setCode" : "TN23",
+  "printNumber" : 16,
   "rarity" : "quarter century secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "TRC1-SC005",
+  "setCode" : "TRC1",
+  "printNumber" : 5,
   "rarity" : "extra secret rare",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 }, {
   "printCode" : "SD28-SC044",
+  "setCode" : "SD28",
+  "printNumber" : 44,
   "rarity" : "common",
-  "language" : "zh-Hans"
+  "language" : "zh-Hans",
+  "regionCode" : "SC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/trap.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/trap.approved.json
@@ -1,547 +1,952 @@
 [ {
   "printCode" : "SYE-041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SKE-042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "DB1-EN118",
+  "setCode" : "DB1",
+  "printNumber" : 118,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "HL03-EN003",
+  "setCode" : "HL03",
+  "printNumber" : 3,
   "rarity" : "ultra parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSDJ-EN034",
+  "setCode" : "YSDJ",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSDS-EN032",
+  "setCode" : "YSDS",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "5DS1-EN036",
+  "setCode" : "5DS1",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DL09-EN017",
+  "setCode" : "DL09",
+  "printNumber" : 17,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "5DS3-EN030",
+  "setCode" : "5DS3",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS11-EN034",
+  "setCode" : "YS11",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS12-EN032",
+  "setCode" : "YS12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCYW-EN177",
+  "setCode" : "LCYW",
+  "printNumber" : 177,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCJW-EN073",
+  "setCode" : "LCJW",
+  "printNumber" : 73,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSYR-EN038",
+  "setCode" : "YSYR",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YSKR-EN042",
+  "setCode" : "YSKR",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS14-EN031",
+  "setCode" : "YS14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDBT-EN028",
+  "setCode" : "SDBT",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-EN058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
   "language" : "en"
 }, {
   "printCode" : "SDY-027",
+  "setCode" : "SDY",
+  "printNumber" : 27,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDK-033",
+  "setCode" : "SDK",
+  "printNumber" : 33,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDJ-043",
+  "setCode" : "SDJ",
+  "printNumber" : 43,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDP-041",
+  "setCode" : "SDP",
+  "printNumber" : 41,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "DLG1-EN008",
+  "setCode" : "DLG1",
+  "printNumber" : 8,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DT02-EN100",
+  "setCode" : "DT02",
+  "printNumber" : 100,
   "rarity" : "duel terminal normal parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS15-ENF24",
+  "setCode" : "YS15",
+  "printNumber" : 24,
+  "printNumberPrefix" : "F",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS15-ENL24",
+  "setCode" : "YS15",
+  "printNumber" : 24,
+  "printNumberPrefix" : "L",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-E046",
+  "setCode" : "LOB",
+  "printNumber" : 46,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "SDY-E025",
+  "setCode" : "SDY",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "SDK-E030",
+  "setCode" : "SDK",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "E"
 }, {
   "printCode" : "RP01-EN007",
+  "setCode" : "RP01",
+  "printNumber" : 7,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "YS15-ENY17",
+  "setCode" : "YS15",
+  "printNumber" : 17,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LOB-A058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "SDY-A027",
+  "setCode" : "SDY",
+  "printNumber" : 27,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "SDK-A033",
+  "setCode" : "SDK",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "A"
 }, {
   "printCode" : "LOB-058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDY-027",
+  "setCode" : "SDY",
+  "printNumber" : 27,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SDK-033",
+  "setCode" : "SDK",
+  "printNumber" : 33,
   "rarity" : "common",
   "language" : "en"
 }, {
   "printCode" : "SSD2-AE017",
+  "setCode" : "SSD2",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "AE"
 }, {
   "printCode" : "LOB-G046",
+  "setCode" : "LOB",
+  "printNumber" : 46,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDY-G025",
+  "setCode" : "SDY",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDK-G030",
+  "setCode" : "SDK",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDJ-G043",
+  "setCode" : "SDJ",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SDP-G041",
+  "setCode" : "SDP",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "G"
 }, {
   "printCode" : "SYE-DE041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SKE-DE042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DB1-DE118",
+  "setCode" : "DB1",
+  "printNumber" : 118,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSDJ-DE034",
+  "setCode" : "YSDJ",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSDS-DE032",
+  "setCode" : "YSDS",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RP01-DE007",
+  "setCode" : "RP01",
+  "printNumber" : 7,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "5DS1-DE036",
+  "setCode" : "5DS1",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DL09-DE017",
+  "setCode" : "DL09",
+  "printNumber" : 17,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "5DS3-DE030",
+  "setCode" : "5DS3",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS11-DE034",
+  "setCode" : "YS11",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS12-DE032",
+  "setCode" : "YS12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCYW-DE177",
+  "setCode" : "LCYW",
+  "printNumber" : 177,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCJW-DE073",
+  "setCode" : "LCJW",
+  "printNumber" : 73,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSYR-DE038",
+  "setCode" : "YSYR",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YSKR-DE042",
+  "setCode" : "YSKR",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS14-DE031",
+  "setCode" : "YS14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "YS15-DEY17",
+  "setCode" : "YS15",
+  "printNumber" : 17,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDBT-DE028",
+  "setCode" : "SDBT",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LOB-DE058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LDD-S058",
+  "setCode" : "LDD",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIY-S027",
+  "setCode" : "BIY",
+  "printNumber" : 27,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIK-S033",
+  "setCode" : "BIK",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIJ-S043",
+  "setCode" : "BIJ",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "BIP-S041",
+  "setCode" : "BIP",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "S"
 }, {
   "printCode" : "SYE-SP041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SKE-SP042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DB1-SP118",
+  "setCode" : "DB1",
+  "printNumber" : 118,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSDJ-SP034",
+  "setCode" : "YSDJ",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSDS-SP032",
+  "setCode" : "YSDS",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "5DS1-SP036",
+  "setCode" : "5DS1",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DL09-SP017",
+  "setCode" : "DL09",
+  "printNumber" : 17,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "5DS3-SP030",
+  "setCode" : "5DS3",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS11-SP034",
+  "setCode" : "YS11",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS12-SP032",
+  "setCode" : "YS12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCYW-SP177",
+  "setCode" : "LCYW",
+  "printNumber" : 177,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LCJW-SP073",
+  "setCode" : "LCJW",
+  "printNumber" : 73,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSYR-SP038",
+  "setCode" : "YSYR",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YSKR-SP042",
+  "setCode" : "YSKR",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS14-SP031",
+  "setCode" : "YS14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "YS15-SPY17",
+  "setCode" : "YS15",
+  "printNumber" : 17,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDBT-SP028",
+  "setCode" : "SDBT",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LOB-SP058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LDD-F046",
+  "setCode" : "LDD",
+  "printNumber" : 46,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDY-F025",
+  "setCode" : "DDY",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDK-F030",
+  "setCode" : "DDK",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDJ-F043",
+  "setCode" : "DDJ",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "DDP-F041",
+  "setCode" : "DDP",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "F"
 }, {
   "printCode" : "SYE-FR041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SKE-FR042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSDJ-FR034",
+  "setCode" : "YSDJ",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSDS-FR032",
+  "setCode" : "YSDS",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RP01-FR007",
+  "setCode" : "RP01",
+  "printNumber" : 7,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "5DS1-FR036",
+  "setCode" : "5DS1",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DL09-FR017",
+  "setCode" : "DL09",
+  "printNumber" : 17,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "5DS3-FR030",
+  "setCode" : "5DS3",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS11-FR034",
+  "setCode" : "YS11",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS12-FR032",
+  "setCode" : "YS12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCYW-FR177",
+  "setCode" : "LCYW",
+  "printNumber" : 177,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LCJW-FR073",
+  "setCode" : "LCJW",
+  "printNumber" : 73,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSYR-FR038",
+  "setCode" : "YSYR",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YSKR-FR042",
+  "setCode" : "YSKR",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS14-FR031",
+  "setCode" : "YS14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "YS15-FRY17",
+  "setCode" : "YS15",
+  "printNumber" : 17,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDBT-FR028",
+  "setCode" : "SDBT",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LOB-FR058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LDD-C058",
+  "setCode" : "LDD",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "DDY-C027",
+  "setCode" : "DDY",
+  "printNumber" : 27,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "DDK-C033",
+  "setCode" : "DDK",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "C"
 }, {
   "printCode" : "LDD-I046",
+  "setCode" : "LDD",
+  "printNumber" : 46,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIY-I025",
+  "setCode" : "MIY",
+  "printNumber" : 25,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIK-I030",
+  "setCode" : "MIK",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIJ-I043",
+  "setCode" : "MIJ",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "MIP-I041",
+  "setCode" : "MIP",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "I"
 }, {
   "printCode" : "SYE-IT041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SKE-IT042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSDJ-IT034",
+  "setCode" : "YSDJ",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSDS-IT032",
+  "setCode" : "YSDS",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RP01-IT007",
+  "setCode" : "RP01",
+  "printNumber" : 7,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "5DS1-IT036",
+  "setCode" : "5DS1",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DL09-IT017",
+  "setCode" : "DL09",
+  "printNumber" : 17,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "5DS3-IT030",
+  "setCode" : "5DS3",
+  "printNumber" : 30,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS11-IT034",
+  "setCode" : "YS11",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS12-IT032",
+  "setCode" : "YS12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCYW-IT177",
+  "setCode" : "LCYW",
+  "printNumber" : 177,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCJW-IT073",
+  "setCode" : "LCJW",
+  "printNumber" : 73,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSYR-IT038",
+  "setCode" : "YSYR",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YSKR-IT042",
+  "setCode" : "YSKR",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS14-IT031",
+  "setCode" : "YS14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "YS15-ITY17",
+  "setCode" : "YS15",
+  "printNumber" : 17,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDBT-IT028",
+  "setCode" : "SDBT",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LOB-IT058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "setCode" : "Vol.1",
   "rarity" : "super rare",
@@ -552,258 +957,454 @@
   "language" : "ja"
 }, {
   "printCode" : "LB-57",
+  "setCode" : "LB",
+  "printNumber" : 57,
   "rarity" : "super rare",
   "language" : "ja"
 }, {
   "printCode" : "EX-27",
+  "setCode" : "EX",
+  "printNumber" : 27,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "JY-30",
+  "setCode" : "JY",
+  "printNumber" : 30,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "DL2-039",
+  "setCode" : "DL2",
+  "printNumber" : 39,
   "rarity" : "rare",
   "language" : "ja"
 }, {
   "printCode" : "SY2-052",
+  "setCode" : "SY2",
+  "printNumber" : 52,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "PC2-007",
+  "setCode" : "PC2",
+  "printNumber" : 7,
   "rarity" : "common",
   "language" : "ja"
 }, {
   "printCode" : "PC2-007",
+  "setCode" : "PC2",
+  "printNumber" : 7,
   "rarity" : "normal parallel rare",
   "language" : "ja"
 }, {
   "printCode" : "BE1-JP118",
+  "setCode" : "BE1",
+  "printNumber" : 118,
   "rarity" : "rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "YSD2-JP034",
+  "setCode" : "YSD2",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "YSD3-JP036",
+  "setCode" : "YSD3",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DT04-JP050",
+  "setCode" : "DT04",
+  "printNumber" : 50,
   "rarity" : "duel terminal normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "YSD5-JP033",
+  "setCode" : "YSD5",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS03-JP018",
+  "setCode" : "GS03",
+  "printNumber" : 18,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GS03-JP018",
+  "setCode" : "GS03",
+  "printNumber" : 18,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "YSD6-JP034",
+  "setCode" : "YSD6",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "BE01-JP101",
+  "setCode" : "BE01",
+  "printNumber" : 101,
   "rarity" : "rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "ST12-JP032",
+  "setCode" : "ST12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "GDB1-JP058",
+  "setCode" : "GDB1",
+  "printNumber" : 58,
   "rarity" : "gold rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HD13-JPL17",
+  "setCode" : "HD13",
+  "printNumber" : 17,
+  "printNumberPrefix" : "L",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HD13-JPD17",
+  "setCode" : "HD13",
+  "printNumber" : 17,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "ST14-JP031",
+  "setCode" : "ST14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "VS15-JPS23",
+  "setCode" : "VS15",
+  "printNumber" : 23,
+  "printNumberPrefix" : "S",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "VS15-JPD24",
+  "setCode" : "VS15",
+  "printNumber" : 24,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HD18-JPL17",
+  "setCode" : "HD18",
+  "printNumber" : 17,
+  "printNumberPrefix" : "L",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HD18-JPD17",
+  "setCode" : "HD18",
+  "printNumber" : 17,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SSD2-JP017",
+  "setCode" : "SSD2",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD45-JP028",
+  "setCode" : "SD45",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "LOB-K058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "SDY-K027",
+  "setCode" : "SDY",
+  "printNumber" : 27,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "SDK-K033",
+  "setCode" : "SDK",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "K"
 }, {
   "printCode" : "SDJ-KR043",
+  "setCode" : "SDJ",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SDP-KR041",
+  "setCode" : "SDP",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SYE-KR041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SKE-KR042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "BP1-KR118",
+  "setCode" : "BP1",
+  "printNumber" : 118,
   "rarity" : "rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "ESP1-KR005",
+  "setCode" : "ESP1",
+  "printNumber" : 5,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "YSD3-KR036",
+  "setCode" : "YSD3",
+  "printNumber" : 36,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "YSD5-KR033",
+  "setCode" : "YSD5",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS03-KR018",
+  "setCode" : "GS03",
+  "printNumber" : 18,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "GS03-KR018",
+  "setCode" : "GS03",
+  "printNumber" : 18,
   "rarity" : "gold rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "YSD6-KR034",
+  "setCode" : "YSD6",
+  "printNumber" : 34,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "ST12-KR032",
+  "setCode" : "ST12",
+  "printNumber" : 32,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "ST14-KR031",
+  "setCode" : "ST14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "VS15-KRS23",
+  "setCode" : "VS15",
+  "printNumber" : 23,
+  "printNumberPrefix" : "S",
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "VS15-KRD24",
+  "setCode" : "VS15",
+  "printNumber" : 24,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SSD2-KR017",
+  "setCode" : "SSD2",
+  "printNumber" : 17,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD45-KR028",
+  "setCode" : "SD45",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "LDB-P058",
+  "setCode" : "LDB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIY-P027",
+  "setCode" : "DIY",
+  "printNumber" : 27,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIK-P033",
+  "setCode" : "DIK",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIJ-P043",
+  "setCode" : "DIJ",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "DIP-P041",
+  "setCode" : "DIP",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "P"
 }, {
   "printCode" : "SYE-PT041",
+  "setCode" : "SYE",
+  "printNumber" : 41,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SKE-PT042",
+  "setCode" : "SKE",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LCJW-PT073",
+  "setCode" : "LCJW",
+  "printNumber" : 73,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YSYR-PT038",
+  "setCode" : "YSYR",
+  "printNumber" : 38,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YSKR-PT042",
+  "setCode" : "YSKR",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YS14-PT031",
+  "setCode" : "YS14",
+  "printNumber" : 31,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "YS15-PTY17",
+  "setCode" : "YS15",
+  "printNumber" : 17,
+  "printNumberPrefix" : "Y",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SDBT-PT028",
+  "setCode" : "SDBT",
+  "printNumber" : 28,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LOB-PT058",
+  "setCode" : "LOB",
+  "printNumber" : 58,
   "rarity" : "super rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "ST14-TC033",
+  "setCode" : "ST14",
+  "printNumber" : 33,
   "rarity" : "common",
-  "language" : "zh-Hant"
+  "language" : "zh-Hant",
+  "regionCode" : "TC"
 }, {
   "printCode" : "HD13-TCL17",
+  "setCode" : "HD13",
+  "printNumber" : 17,
+  "printNumberPrefix" : "L",
   "rarity" : "common",
-  "language" : "zh-Hant"
+  "language" : "zh-Hant",
+  "regionCode" : "TC"
 }, {
   "printCode" : "HD13-TCD17",
+  "setCode" : "HD13",
+  "printNumber" : 17,
+  "printNumberPrefix" : "D",
   "rarity" : "common",
-  "language" : "zh-Hant"
+  "language" : "zh-Hant",
+  "regionCode" : "TC"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/undefined_atk_def.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/undefined_atk_def.approved.json
@@ -1,333 +1,594 @@
 [ {
   "printCode" : "POTD-EN034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "POTD-EN034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DP04-EN013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "GLD1-EN029",
+  "setCode" : "GLD1",
+  "printNumber" : 29,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LCGX-EN183",
+  "setCode" : "LCGX",
+  "printNumber" : 183,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RYMP-EN061",
+  "setCode" : "RYMP",
+  "printNumber" : 61,
   "rarity" : "rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SP14-EN043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SP14-EN043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "starfoil rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "PGLD-EN056",
+  "setCode" : "PGLD",
+  "printNumber" : 56,
   "rarity" : "gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "LEDD-ENB27",
+  "setCode" : "LEDD",
+  "printNumber" : 27,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SDCS-EN042",
+  "setCode" : "SDCS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "SGX1-ENG22",
+  "setCode" : "SGX1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "G",
   "rarity" : "common",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "DT07-EN032",
+  "setCode" : "DT07",
+  "printNumber" : 32,
   "rarity" : "duel terminal rare parallel rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "POTD-DE034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "POTD-DE034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "DP04-DE013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "GLD1-DE029",
+  "setCode" : "GLD1",
+  "printNumber" : 29,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LCGX-DE183",
+  "setCode" : "LCGX",
+  "printNumber" : 183,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RYMP-DE061",
+  "setCode" : "RYMP",
+  "printNumber" : 61,
   "rarity" : "rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SP14-DE043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SP14-DE043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "starfoil rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "PGLD-DE056",
+  "setCode" : "PGLD",
+  "printNumber" : 56,
   "rarity" : "gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "LEDD-DEB27",
+  "setCode" : "LEDD",
+  "printNumber" : 27,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SDCS-DE042",
+  "setCode" : "SDCS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "SGX1-DEG22",
+  "setCode" : "SGX1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "G",
   "rarity" : "common",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "POTD-SP034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "POTD-SP034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "DP04-SP013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "GLD1-SP029",
+  "setCode" : "GLD1",
+  "printNumber" : 29,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RYMP-SP061",
+  "setCode" : "RYMP",
+  "printNumber" : 61,
   "rarity" : "rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SP14-SP043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SP14-SP043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "starfoil rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "PGLD-SP056",
+  "setCode" : "PGLD",
+  "printNumber" : 56,
   "rarity" : "gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "LEDD-SPB27",
+  "setCode" : "LEDD",
+  "printNumber" : 27,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SDCS-SP042",
+  "setCode" : "SDCS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "SGX1-SPG22",
+  "setCode" : "SGX1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "G",
   "rarity" : "common",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "POTD-FR034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "POTD-FR034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "DP04-FR013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "GLD1-FR029",
+  "setCode" : "GLD1",
+  "printNumber" : 29,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RYMP-FR061",
+  "setCode" : "RYMP",
+  "printNumber" : 61,
   "rarity" : "rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SP14-FR043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SP14-FR043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "starfoil rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "PGLD-FR056",
+  "setCode" : "PGLD",
+  "printNumber" : 56,
   "rarity" : "gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "LEDD-FRB27",
+  "setCode" : "LEDD",
+  "printNumber" : 27,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SDCS-FR042",
+  "setCode" : "SDCS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "SGX1-FRG22",
+  "setCode" : "SGX1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "G",
   "rarity" : "common",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "POTD-IT034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "POTD-IT034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "DP04-IT013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "GLD1-IT029",
+  "setCode" : "GLD1",
+  "printNumber" : 29,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LCGX-IT183",
+  "setCode" : "LCGX",
+  "printNumber" : 183,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RYMP-IT061",
+  "setCode" : "RYMP",
+  "printNumber" : 61,
   "rarity" : "rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SP14-IT043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SP14-IT043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "starfoil rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "PGLD-IT056",
+  "setCode" : "PGLD",
+  "printNumber" : 56,
   "rarity" : "gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "LEDD-ITB27",
+  "setCode" : "LEDD",
+  "printNumber" : 27,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SDCS-IT042",
+  "setCode" : "SDCS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "SGX1-ITG22",
+  "setCode" : "SGX1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "G",
   "rarity" : "common",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "POTD-JP034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "POTD-JP034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DP04-JP013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DT13-JP032",
+  "setCode" : "DT13",
+  "printNumber" : 32,
   "rarity" : "duel terminal rare parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "DE01-JP026",
+  "setCode" : "DE01",
+  "printNumber" : 26,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "SD41-JP042",
+  "setCode" : "SD41",
+  "printNumber" : 42,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HC01-JP017",
+  "setCode" : "HC01",
+  "printNumber" : 17,
   "rarity" : "normal parallel rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HC01-JP017",
+  "setCode" : "HC01",
+  "printNumber" : 17,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "HC01-JP017",
+  "setCode" : "HC01",
+  "printNumber" : 17,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "????-JP001",
+  "setCode" : "????",
+  "printNumber" : 1,
   "rarity" : "quarter century secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "POTD-KR034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "POTD-KR034",
+  "setCode" : "POTD",
+  "printNumber" : 34,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "DP04-KR013",
+  "setCode" : "DP04",
+  "printNumber" : 13,
   "rarity" : "rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "PC01-KR027",
+  "setCode" : "PC01",
+  "printNumber" : 27,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SD41-KR042",
+  "setCode" : "SD41",
+  "printNumber" : 42,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "HC01-KR017",
+  "setCode" : "HC01",
+  "printNumber" : 17,
   "rarity" : "normal parallel rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "HC01-KR017",
+  "setCode" : "HC01",
+  "printNumber" : 17,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "HC01-KR017",
+  "setCode" : "HC01",
+  "printNumber" : 17,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "SP14-PT043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SP14-PT043",
+  "setCode" : "SP14",
+  "printNumber" : 43,
   "rarity" : "starfoil rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "PGLD-PT056",
+  "setCode" : "PGLD",
+  "printNumber" : 56,
   "rarity" : "gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "LEDD-PTB27",
+  "setCode" : "LEDD",
+  "printNumber" : 27,
+  "printNumberPrefix" : "B",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SDCS-PT042",
+  "setCode" : "SDCS",
+  "printNumber" : 42,
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "SGX1-PTG22",
+  "setCode" : "SGX1",
+  "printNumber" : 22,
+  "printNumberPrefix" : "G",
   "rarity" : "common",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 } ]

--- a/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/xyz_monster.approved.json
+++ b/tools/src/test/resources/io/github/ygojson/tools/dataprovider/impl/yugipedia/acceptance/YugipediaPrintMapper/xyz_monster.approved.json
@@ -1,97 +1,169 @@
 [ {
   "printCode" : "RATE-EN053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MP17-EN208",
+  "setCode" : "MP17",
+  "printNumber" : 208,
   "rarity" : "secret rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "MAGO-EN036",
+  "setCode" : "MAGO",
+  "printNumber" : 36,
   "rarity" : "premium gold rare",
-  "language" : "en"
+  "language" : "en",
+  "regionCode" : "EN"
 }, {
   "printCode" : "RATE-DE053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MP17-DE208",
+  "setCode" : "MP17",
+  "printNumber" : 208,
   "rarity" : "secret rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "MAGO-DE036",
+  "setCode" : "MAGO",
+  "printNumber" : 36,
   "rarity" : "premium gold rare",
-  "language" : "de"
+  "language" : "de",
+  "regionCode" : "DE"
 }, {
   "printCode" : "RATE-SP053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MP17-SP208",
+  "setCode" : "MP17",
+  "printNumber" : 208,
   "rarity" : "secret rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "MAGO-SP036",
+  "setCode" : "MAGO",
+  "printNumber" : 36,
   "rarity" : "premium gold rare",
-  "language" : "es"
+  "language" : "es",
+  "regionCode" : "SP"
 }, {
   "printCode" : "RATE-FR053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MP17-FR208",
+  "setCode" : "MP17",
+  "printNumber" : 208,
   "rarity" : "secret rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "MAGO-FR036",
+  "setCode" : "MAGO",
+  "printNumber" : 36,
   "rarity" : "premium gold rare",
-  "language" : "fr"
+  "language" : "fr",
+  "regionCode" : "FR"
 }, {
   "printCode" : "RATE-IT053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MP17-IT208",
+  "setCode" : "MP17",
+  "printNumber" : 208,
   "rarity" : "secret rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "MAGO-IT036",
+  "setCode" : "MAGO",
+  "printNumber" : 36,
   "rarity" : "premium gold rare",
-  "language" : "it"
+  "language" : "it",
+  "regionCode" : "IT"
 }, {
   "printCode" : "RATE-JP053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "ultra rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RATE-JP053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RATE-JP053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "ultimate rare",
-  "language" : "ja"
+  "language" : "ja",
+  "regionCode" : "JP"
 }, {
   "printCode" : "RATE-KR053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "ultra rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RATE-KR053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RATE-KR053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "ultimate rare",
-  "language" : "ko"
+  "language" : "ko",
+  "regionCode" : "KR"
 }, {
   "printCode" : "RATE-PT053",
+  "setCode" : "RATE",
+  "printNumber" : 53,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MP17-PT208",
+  "setCode" : "MP17",
+  "printNumber" : 208,
   "rarity" : "secret rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 }, {
   "printCode" : "MAGO-PT036",
+  "setCode" : "MAGO",
+  "printNumber" : 36,
   "rarity" : "premium gold rare",
-  "language" : "pt"
+  "language" : "pt",
+  "regionCode" : "PT"
 } ]


### PR DESCRIPTION
- Refactor YugipediaPrintMapper to use directly `CardNumber` model and mapper
- Update unit and acceptance tests