### PR TITLE
Fix application config profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,10 @@
         <skipLint>false</skipLint>
         <skipITs>true</skipITs>
         <!-- test tags used to override in contract test -->
+        <testTags.contractTest>contract-test</testTags.contractTest>
+        <testTags.acceptanceTest>acceptance-test</testTags.acceptanceTest>
         <includedTestTags></includedTestTags>
-        <excludedTestTags>contract-test</excludedTestTags>
+        <excludedTestTags>${testTags.contractTest}</excludedTestTags>
 
         <!-- quarkus dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
@@ -352,6 +354,8 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
+                        <quarkus.log.console.stderr>true</quarkus.log.console.stderr>
+                        <quarkus.test.exclude-tags>${testTags.acceptanceTest}</quarkus.test.exclude-tags>
                     </systemPropertyVariables>
                     <excludedGroups>${excludedTestTags}</excludedGroups>
                     <groups>${includedTestTags}</groups>
@@ -373,6 +377,8 @@
                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
+                        <quarkus.log.console.stderr>true</quarkus.log.console.stderr>
+                        <quarkus.test.exclude-tags>${testTags.acceptanceTest}</quarkus.test.exclude-tags>
                     </systemPropertyVariables>
                     <excludedGroups>${excludedTestTags}</excludedGroups>
                     <groups>${includedTestTags}</groups>
@@ -420,7 +426,7 @@
                 </property>
             </activation>
             <properties>
-                <includedTestTags>contract-test</includedTestTags>
+                <includedTestTags>${testTags.contractTest}</includedTestTags>
                 <excludedTestTags></excludedTestTags>
             </properties>
         </profile>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,8 @@ quarkus:
   log:
     level: "INFO"
     console:
+      stderr: true
       format: "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n"
     category:
-      "io.github.ygojson.application":
+      "io.github.ygojson":
         level: "DEBUG"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,4 @@
 quarkus:
-  test:
-    exclude-tags:
-      - "acceptance-test"
   log:
     level: "INFO"
     console:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,10 @@ quarkus:
   log:
     level: "WARN"
     console:
+      stderr: true
       format: "[%-5p - %d{yyyy-MM-dd HH:mm:ss}] - %s%n"
     category:
-      "io.github.ygojson.application":
+      "io.github.ygojson":
         level: "INFO"
   banner:
     path: banner.txt


### PR DESCRIPTION
- Acceptance-test ignore during quarkus tests should be done at the pom level
- Extracted test-tags properties in pom to simplify the configuration
- Console logs should go to the stderr (to be able to see them when running the cli but easily output to a file if required)
- Console logs for the ygojson category were only using the application module