### PR TITLE
Provide ApplicationInfo with quarkus properties

### DIFF
--- a/src/main/java/io/github/ygojson/application/ApplicationInfo.java
+++ b/src/main/java/io/github/ygojson/application/ApplicationInfo.java
@@ -5,8 +5,8 @@ package io.github.ygojson.application;
  * <br>
  * This information would be populated with quarkus to get the information from the application on runtime.
  *
- * @param title title of the application
+ * @param name name of the application
  * @param version version of the application
  * @param url url from the application
  */
-public record ApplicationInfo(String title, String version, String url) {}
+public record ApplicationInfo(String name, String version, String url) {}

--- a/src/main/java/io/github/ygojson/application/yugipedia/client/Config.java
+++ b/src/main/java/io/github/ygojson/application/yugipedia/client/Config.java
@@ -55,9 +55,9 @@ class Config implements ClientConfig<YugipediaClient> {
 	}
 
 	private static String getClientNameVersion(ApplicationInfo info) {
-		if (info.title() != null) {
+		if (info.name() != null) {
 			return (
-				info.title() +
+				info.name() +
 				"/" +
 				(info.version() != null ? info.version() : "unknown")
 			);

--- a/src/main/java/io/github/ygojson/runtime/ApplicationConfig.java
+++ b/src/main/java/io/github/ygojson/runtime/ApplicationConfig.java
@@ -33,10 +33,6 @@ public class ApplicationConfig {
 	@Produces
 	@Dependent
 	public ApplicationInfo applicationInfo() {
-		return new ApplicationInfo(
-			applicationName,
-			applicationVersion,
-			ygojsonUrl
-		);
+		return new ApplicationInfo(applicationName, applicationVersion, ygojsonUrl);
 	}
 }

--- a/src/main/java/io/github/ygojson/runtime/ApplicationConfig.java
+++ b/src/main/java/io/github/ygojson/runtime/ApplicationConfig.java
@@ -1,0 +1,42 @@
+package io.github.ygojson.runtime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.github.ygojson.application.ApplicationInfo;
+
+/**
+ * Configuration for the shared beans of the ygojson-tools application.
+ */
+@ApplicationScoped
+public class ApplicationConfig {
+
+	@ConfigProperty(
+		name = "quarkus.application.name",
+		defaultValue = "ygojson-tools"
+	)
+	String applicationName;
+
+	@ConfigProperty(name = "quarkus.application.version", defaultValue = "0.0.0")
+	String applicationVersion;
+
+	@ConfigProperty(name = "ygojson.url")
+	String userAgentUrl = null;
+
+	/**
+	 * Produces the application info configured with the properties.
+	 *
+	 * @return the application info instance.
+	 */
+	@Produces
+	@Dependent
+	public ApplicationInfo applicationInfo() {
+		return new ApplicationInfo(
+			applicationName,
+			applicationVersion,
+			userAgentUrl
+		);
+	}
+}

--- a/src/main/java/io/github/ygojson/runtime/ApplicationConfig.java
+++ b/src/main/java/io/github/ygojson/runtime/ApplicationConfig.java
@@ -23,7 +23,7 @@ public class ApplicationConfig {
 	String applicationVersion;
 
 	@ConfigProperty(name = "ygojson.url")
-	String userAgentUrl = null;
+	String ygojsonUrl = null;
 
 	/**
 	 * Produces the application info configured with the properties.
@@ -36,7 +36,7 @@ public class ApplicationConfig {
 		return new ApplicationInfo(
 			applicationName,
 			applicationVersion,
-			userAgentUrl
+			ygojsonUrl
 		);
 	}
 }

--- a/src/main/java/io/github/ygojson/runtime/package-info.java
+++ b/src/main/java/io/github/ygojson/runtime/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Runtime package contains configuration for the runtime on Quarkus.
+ * <br>
+ * All beans and configuration properties that need a specific configuration are located in this package.
+ */
+package io.github.ygojson.runtime;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,4 @@
+# overriden quarkus config
 quarkus:
   log:
     level: "INFO"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+# ygojson-specific properties
+ygojson:
+  url: "https://github.com/ygojson/ygojson-tools"
+
+# quarkus config
 quarkus:
   log:
     level: "WARN"

--- a/src/test/java/io/github/ygojson/runtime/ApplicationConfigTest.java
+++ b/src/test/java/io/github/ygojson/runtime/ApplicationConfigTest.java
@@ -17,7 +17,7 @@ class ApplicationConfigTest {
 	@Test
 	void testApplicationInfo() {
 		assertSoftly(softly -> {
-			softly.assertThat(info.name()).describedAs("url").isNotBlank();
+			softly.assertThat(info.name()).describedAs("name").isNotBlank();
 			softly.assertThat(info.version()).describedAs("version").isNotBlank();
 			softly.assertThat(info.url()).describedAs("url").isNotBlank();
 		});

--- a/src/test/java/io/github/ygojson/runtime/ApplicationConfigTest.java
+++ b/src/test/java/io/github/ygojson/runtime/ApplicationConfigTest.java
@@ -1,8 +1,9 @@
 package io.github.ygojson.runtime;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 import io.github.ygojson.application.ApplicationInfo;
@@ -15,7 +16,7 @@ class ApplicationConfigTest {
 
 	@Test
 	void testApplicationInfo() {
-		SoftAssertions.assertSoftly(softly -> {
+		assertSoftly(softly -> {
 			softly.assertThat(info.name()).describedAs("url").isNotBlank();
 			softly.assertThat(info.version()).describedAs("version").isNotBlank();
 			softly.assertThat(info.url()).describedAs("url").isNotBlank();

--- a/src/test/java/io/github/ygojson/runtime/ApplicationConfigTest.java
+++ b/src/test/java/io/github/ygojson/runtime/ApplicationConfigTest.java
@@ -1,0 +1,24 @@
+package io.github.ygojson.runtime;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import io.github.ygojson.application.ApplicationInfo;
+
+@QuarkusTest
+class ApplicationConfigTest {
+
+	@Inject
+	ApplicationInfo info;
+
+	@Test
+	void testApplicationInfo() {
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(info.name()).describedAs("url").isNotBlank();
+			softly.assertThat(info.version()).describedAs("version").isNotBlank();
+			softly.assertThat(info.url()).describedAs("url").isNotBlank();
+		});
+	}
+}


### PR DESCRIPTION
- Rename `ApplicationInfo::title` to `ApplicationInfo::name`
- Create `ApplicationInfo` bean using quarkus properties 
- Add `ygojson.url' property to be used on the application-info configuration

Closes #19 