### PR TITLE
Add PrintEntity with repository and mapper to/from model

### DIFF
--- a/src/main/java/io/github/ygojson/application/core/db/print/PrintEntity.java
+++ b/src/main/java/io/github/ygojson/application/core/db/print/PrintEntity.java
@@ -1,0 +1,64 @@
+package io.github.ygojson.application.core.db.print;
+
+import jakarta.persistence.*;
+
+import io.github.ygojson.application.core.db.RuntimeBaseEntity;
+import io.github.ygojson.application.core.db.card.CardEntity;
+import io.github.ygojson.application.core.db.set.SetEntity;
+import io.github.ygojson.model.data.definition.localization.Language;
+import io.github.ygojson.model.data.definition.localization.Region;
+
+/**
+ * Print-entity.
+ * <br>
+ * Note that the {@link #id} is internal for the database,
+ * and it is not related with the YGOJSON model.
+ */
+@Entity
+@Table(name = "tbl_print")
+@AttributeOverride(
+	name = RuntimeBaseEntity.ID_COLUMN,
+	column = @Column(name = "print_id")
+)
+public class PrintEntity extends RuntimeBaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(
+		name = "card_id",
+		foreignKey = @ForeignKey(value = ConstraintMode.CONSTRAINT)
+	)
+	public CardEntity card;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(
+		name = "set_id",
+		foreignKey = @ForeignKey(value = ConstraintMode.CONSTRAINT)
+	)
+	public SetEntity set;
+
+	@Column(name = "print_code")
+	public String printCode;
+
+	@Column(name = "setcode")
+	public String setCode;
+
+	@Column(name = "print_number_prefix")
+	public String printNumberPrefix;
+
+	@Column(name = "print_number")
+	public String printNumber;
+
+	@Column(name = "print_number_suffix")
+	public String printNumberSuffix;
+
+	// maybe this should be a
+	@Column(name = "rarity")
+	public String rarity;
+
+	@Enumerated(EnumType.STRING)
+	public Language language;
+
+	@Column(name = "region_code")
+	@Enumerated(EnumType.STRING)
+	public Region regionCode;
+}

--- a/src/main/java/io/github/ygojson/application/core/db/print/PrintRepository.java
+++ b/src/main/java/io/github/ygojson/application/core/db/print/PrintRepository.java
@@ -1,0 +1,11 @@
+package io.github.ygojson.application.core.db.print;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.github.ygojson.application.core.db.RuntimeRepository;
+
+/**
+ * Repository for {@link PrintEntity}.
+ */
+@ApplicationScoped
+public class PrintRepository extends RuntimeRepository<PrintEntity> {}

--- a/src/main/java/io/github/ygojson/application/logic/mapper/PrintMapper.java
+++ b/src/main/java/io/github/ygojson/application/logic/mapper/PrintMapper.java
@@ -1,0 +1,26 @@
+package io.github.ygojson.application.logic.mapper;
+
+import org.mapstruct.*;
+
+import io.github.ygojson.application.core.db.print.PrintEntity;
+import io.github.ygojson.model.data.Print;
+
+/**
+ * Mapper between the {@link Print} model and the {@link PrintEntity}.
+ */
+@Mapper(
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR,
+	componentModel = MappingConstants.ComponentModel.JAKARTA_CDI
+)
+public abstract class PrintMapper {
+
+	@Mapping(target = "id", source = "ygojsonId")
+	@Mapping(target = "cardId", source = "card.ygojsonId")
+	@Mapping(target = "setId", source = "set.ygojsonId")
+	public abstract Print toModel(PrintEntity entity);
+
+	@InheritInverseConfiguration
+	@Mapping(target = "id", ignore = true)
+	public abstract PrintEntity toEntity(Print model);
+}

--- a/src/main/resources/db/migration/V0.0.3__create_print_table.sql
+++ b/src/main/resources/db/migration/V0.0.3__create_print_table.sql
@@ -1,0 +1,27 @@
+CREATE TABLE
+    IF NOT EXISTS "tbl_print" (
+        "print_id" VARCHAR(36) UNIQUE,
+        "ygojson_id" VARCHAR(36) UNIQUE,
+        "set_id" VARCHAR(36),
+        "card_id" VARCHAR(36),
+        "print_code" TEXT,
+        "setcode" TEXT,
+        "print_number_prefix" TEXT,
+        "print_number" TEXT,
+        "print_number_suffix" TEXT,
+        "rarity" TEXT,
+        "language" TEXT,
+        "region_code" TEXT,
+        -- TODO: decide the cascading mode
+        FOREIGN KEY ("card_id") REFERENCES "tbl_card" ("card_id"),
+        FOREIGN KEY ("set_id") REFERENCES "tbl_set" ("set_id"),
+        PRIMARY KEY ("print_id")
+    );
+
+CREATE UNIQUE INDEX "index.tbl_print.id" ON "tbl_print" ("print_id");
+
+CREATE UNIQUE INDEX "index.tbl_print.ygojson_id" ON "tbl_print" ("ygojson_id");
+
+CREATE INDEX "index.tbl_print.print_code" ON "tbl_print" ("print_code");
+
+CREATE INDEX "index.tbl_print.setcode" ON "tbl_print" ("setcode");

--- a/src/test/java/io/github/ygojson/application/core/db/print/PrintRepositoryUnitTest.java
+++ b/src/test/java/io/github/ygojson/application/core/db/print/PrintRepositoryUnitTest.java
@@ -46,7 +46,14 @@ class PrintRepositoryUnitTest {
 	}
 
 	@Test
-	void given_emptyEntity_when_save_then_repositoryContainsEntity() {}
+	void given_emptyEntity_when_save_then_repositoryContainsEntity() {
+		// given
+		final PrintEntity entity = new PrintEntity();
+		// when
+		final UUID result = repository.save(entity);
+		// then
+		assertThat(result).isNotNull();
+	}
 
 	@Test
 	void given_entityInstanceWithoutId_when_save_then_repositoryContainsEntity() {

--- a/src/test/java/io/github/ygojson/application/core/db/print/PrintRepositoryUnitTest.java
+++ b/src/test/java/io/github/ygojson/application/core/db/print/PrintRepositoryUnitTest.java
@@ -1,0 +1,112 @@
+package io.github.ygojson.application.core.db.print;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
+
+import java.util.UUID;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.ThrowableAssert;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.ygojson.application.core.db.RuntimeBaseEntity;
+
+@QuarkusTest
+class PrintRepositoryUnitTest {
+
+	@Inject
+	PrintRepository repository;
+
+	@BeforeEach
+	@Transactional
+	void beforeEach() {
+		repository.deleteAll();
+	}
+
+	@AfterEach
+	@Transactional
+	void afterAll() {
+		repository.deleteAll();
+	}
+
+	// creates a PrintEntity without references
+	private InstancioApi<PrintEntity> withoutRefs() {
+		return Instancio
+			.of(PrintEntity.class)
+			.ignore(field(PrintEntity.class, "card"))
+			.ignore(field(PrintEntity.class, "set"));
+	}
+
+	@Test
+	void given_emptyEntity_when_save_then_repositoryContainsEntity() {}
+
+	@Test
+	void given_entityInstanceWithoutId_when_save_then_repositoryContainsEntity() {
+		// given
+		final PrintEntity entity = withoutRefs()
+			.ignore(field(RuntimeBaseEntity.class, "id"))
+			.create();
+		// when
+		final UUID result = repository.save(entity);
+		// when
+		assertSoftly(softly -> {
+			softly
+				.assertThat(result)
+				.isNotNull()
+				.extracting(UUID::version)
+				.isEqualTo(7);
+			softly.assertThat(repository.findById(result)).isNotNull();
+		});
+	}
+
+	@Test
+	void given_entityInstanceWithId_when_save_then_isSaved() {
+		// given - entity with ID (cached value for assert)
+		final PrintEntity entity = withoutRefs().create();
+		final String id = entity.id.toString();
+		// when
+		final UUID result = repository.save(entity);
+		// then
+		assertThat(result).isNotNull().extracting(UUID::toString).isEqualTo(id);
+	}
+
+	@Test
+	void given_entityAlreadySaved_when_save_then_fails() {
+		// given
+		final PrintEntity entity = withoutRefs().create();
+		final PrintEntity duplicated = withoutRefs()
+			.set(field(RuntimeBaseEntity.class, "id"), entity.id)
+			.create();
+		// when
+		repository.save(entity);
+		final ThrowableAssert.ThrowingCallable callable = () ->
+			repository.save(duplicated);
+		// then
+		// assert without specific exception so far
+		assertThatThrownBy(callable).isNotNull();
+	}
+
+	@Test
+	void given_entityWithSameYgojsonId_when_save_then_fails() {
+		// given
+		final PrintEntity entity1 = withoutRefs().create();
+		final PrintEntity entity2 = withoutRefs()
+			.set(field(RuntimeBaseEntity.class, "ygojsonId"), entity1.ygojsonId)
+			.create();
+		// when
+		repository.save(entity1);
+		final ThrowableAssert.ThrowingCallable callable = () ->
+			repository.save(entity2);
+		// then
+		// assert without specific exception so far
+		assertThatThrownBy(callable).isNotNull();
+	}
+}

--- a/src/test/java/io/github/ygojson/application/core/db/print/PrintRepositoryWithRefsTest.java
+++ b/src/test/java/io/github/ygojson/application/core/db/print/PrintRepositoryWithRefsTest.java
@@ -1,0 +1,112 @@
+package io.github.ygojson.application.core.db.print;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.instancio.Select.field;
+
+import java.util.UUID;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.ygojson.application.core.db.RuntimeBaseEntity;
+import io.github.ygojson.application.core.db.card.CardEntity;
+import io.github.ygojson.application.core.db.set.SetEntity;
+
+@QuarkusTest
+public class PrintRepositoryWithRefsTest {
+
+	@Inject
+	PrintRepository repository;
+
+	private CardEntity existingCard;
+	private SetEntity existingSet;
+
+	@BeforeEach
+	@Transactional
+	void beforeEach() {
+		createCard();
+		createSet();
+		repository.deleteAll();
+	}
+
+	@Transactional
+	void createCard() {
+		existingCard = new CardEntity();
+		existingCard.id = UUID.randomUUID();
+		existingCard.persist();
+	}
+
+	@Transactional
+	void createSet() {
+		existingSet = new SetEntity();
+		existingSet.id = UUID.randomUUID();
+		existingSet.persist();
+	}
+
+	@AfterEach
+	@Transactional
+	void afterAll() {
+		repository.deleteAll();
+		if (existingCard != null) {
+			existingCard.delete();
+		}
+		if (existingSet != null) {
+			existingSet.delete();
+		}
+	}
+
+	// creates a PrintEntity without references
+	private InstancioApi<PrintEntity> withExistingRefs() {
+		return Instancio
+			.of(PrintEntity.class)
+			.set(field(PrintEntity.class, "card"), existingCard)
+			.set(field(PrintEntity.class, "set"), existingSet);
+	}
+
+	@Test
+	void given_entityInstanceWithRefs_when_save_then_repositoryContainsEntity() {
+		// given
+		final PrintEntity entity = withExistingRefs()
+			.ignore(field(RuntimeBaseEntity.class, "id"))
+			.create();
+		// when
+		final UUID result = repository.save(entity);
+		// when
+		assertSoftly(softly -> {
+			softly
+				.assertThat(result)
+				.isNotNull()
+				.extracting(UUID::version)
+				.isEqualTo(7);
+			softly.assertThat(repository.findById(result)).isNotNull();
+		});
+	}
+
+	@Test
+	void given_entityInstanceWithRefs_when_save_then_retrievedEntityContainsRefs() {
+		// given
+		final PrintEntity entity = withExistingRefs()
+			.ignore(field(RuntimeBaseEntity.class, "id"))
+			.create();
+		// when
+		final UUID result = repository.save(entity);
+		final PrintEntity persistedEntity = repository.findById(result);
+		// when
+		assertSoftly(softly -> {
+			softly
+				.assertThat(persistedEntity.card)
+				.describedAs("card reference")
+				.isNotNull();
+			softly
+				.assertThat(persistedEntity.set)
+				.describedAs("set reference")
+				.isNotNull();
+		});
+	}
+}

--- a/src/test/java/io/github/ygojson/application/logic/mapper/PrintMapperUnitTest.java
+++ b/src/test/java/io/github/ygojson/application/logic/mapper/PrintMapperUnitTest.java
@@ -1,0 +1,31 @@
+package io.github.ygojson.application.logic.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.github.ygojson.application.core.db.print.PrintEntity;
+import io.github.ygojson.model.data.Print;
+
+class PrintMapperUnitTest {
+
+	private static PrintMapper MAPPER;
+
+	@BeforeAll
+	static void beforeAll() {
+		MAPPER = new PrintMapperImpl();
+	}
+
+	@Test
+	void given_instanceModel_when_roundtripMapping_then_equalObject() {
+		// given
+		final Print model = Instancio.of(Print.class).create();
+		// when
+		final PrintEntity entity = MAPPER.toEntity(model);
+		final Print result = MAPPER.toModel(entity);
+		// then
+		assertThat(result).isEqualTo(model);
+	}
+}


### PR DESCRIPTION
- Create PrintEntity and PrintRepository
- Create PrintMapper for conversion between model and entity (and vice-versa)
- Add tests for repository and mapper
